### PR TITLE
Use <h1> instead of <h2> for main page title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,7 +40,7 @@
 	</ul>
       </div>
       <div id="content">
-	<h2>{{ page.title }}</h2>
+	<h1>{{ page.title }}</h1>
       {{ content }}
       </div>
     </div>

--- a/conduct.md
+++ b/conduct.md
@@ -2,11 +2,10 @@
 title: Code of Conduct
 layout: default
 ---
-Contributor Covenant Code of Conduct
-====================================
 
-Our Pledge
-----------
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project
@@ -15,8 +14,7 @@ age, body size, disability, ethnicity, gender identity and expression, level
 of experience, nationality, personal appearance, race, religion, or sexual
 identity and orientation.
 
-Our Standards
--------------
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
@@ -38,8 +36,7 @@ Examples of unacceptable behavior by participants include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-Our Responsibilities
---------------------
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -51,8 +48,7 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-Scope
------
+### Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
@@ -61,8 +57,7 @@ address, posting via an official social media account, or acting as an
 appointed representative at an online or offline event. Representation of a
 project may be further defined and clarified by project maintainers.
 
-Enforcement
------------
+### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting Fabian Deutsch at fabiand-at-fedoraproject-dot-org. All
@@ -76,8 +71,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-Attribution
------------
+### Attribution
 
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
 available at http://contributor-covenant.org/version/1/4.

--- a/contrib.md
+++ b/contrib.md
@@ -26,7 +26,7 @@ need for people to spread knowledge & passion about the project to potential
 new users & contributors.
 
 
-### Instant messaging / chat
+## Instant messaging / chat
 
 The project uses the ``#kubevirt`` IRC channel on the [Freenode
 network](https://irc.freenode.net). IRC is accessible from a wide variety of
@@ -39,7 +39,7 @@ that many members will inevitably miss conversations that take place online.
 For these reasons, detailed technical design discussions are often better held
 over email, leaving IRC for matters which require realtime engagement.
 
-### E-Mail / Forums
+## E-Mail / Forums
 
 The project uses the ``kubevirt-dev`` Google Group as a forum for developer
 discussions. To join the group, visit [the online web
@@ -47,11 +47,11 @@ interface](https://groups.google.com/forum/#!forum/kubevirt-dev). After joining
 messages can be sent either via the web interface, or directly via e-mail to
 the address [``kubevirt-dev@googlegroups.com``](mailto:kubevirt-dev@googlegroups.com)
 
-### Development resources
+## Development resources
 
 The development of KubeVirt relies on a number of online services
 
-### Source repository
+## Source repository
 
 All the source code assocaited with the project is managed in the GIT version
 control system, [hosted on github](https://github.com/kubevirt/). The primary
@@ -61,7 +61,7 @@ repositories are:
 * [kubevirt.github.io](https://github.com/kubevirt/kubevirt.github.io) - The source for this entire website
 * [project-infra](https://github.com/kubevirt/project-infra) - Miscellaneous project infrastructure tools
 
-### Social media
+## Social media
 
 The project maintains a presence in various social media systems to spread news
 and other interesting information related to the project

--- a/css/main.scss
+++ b/css/main.scss
@@ -46,7 +46,7 @@ pre, code {
     background: #eee;
 }
 
-#content h2 {
+#content h1 {
     text-align: center;
 }
 

--- a/docs.md
+++ b/docs.md
@@ -3,6 +3,6 @@ title: Learn about KubeVirt
 layout: default
 ---
 
-### Project overview
+## Project overview
 
 * [Kubevirt use cases](/use-cases)

--- a/license-apache20.md
+++ b/license-apache20.md
@@ -5,9 +5,9 @@ layout: default
 
 <http://www.apache.org/licenses/>
 
-### Terms and Conditions for use, reproduction, and distribution
+## Terms and Conditions for use, reproduction, and distribution
 
-#### 1. Definitions
+### 1. Definitions
 
 “License” shall mean the terms and conditions for use, reproduction, and
 distribution as defined by Sections 1 through 9 of this document.
@@ -61,7 +61,7 @@ owner as “Not a Contribution.”
 of whom a Contribution has been received by Licensor and subsequently
 incorporated within the Work.
 
-#### 2. Grant of Copyright License
+### 2. Grant of Copyright License
 
 Subject to the terms and conditions of this License, each Contributor hereby
 grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
@@ -69,7 +69,7 @@ irrevocable copyright license to reproduce, prepare Derivative Works of,
 publicly display, publicly perform, sublicense, and distribute the Work and such
 Derivative Works in Source or Object form.
 
-#### 3. Grant of Patent License
+### 3. Grant of Patent License
 
 Subject to the terms and conditions of this License, each Contributor hereby
 grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
@@ -84,7 +84,7 @@ Contribution incorporated within the Work constitutes direct or contributory
 patent infringement, then any patent licenses granted to You under this License
 for that Work shall terminate as of the date such litigation is filed.
 
-#### 4. Redistribution
+### 4. Redistribution
 
 You may reproduce and distribute copies of the Work or Derivative Works thereof
 in any medium, with or without modifications, and in Source or Object form,
@@ -118,7 +118,7 @@ distribution of Your modifications, or for any such Derivative Works as a whole,
 provided Your use, reproduction, and distribution of the Work otherwise complies
 with the conditions stated in this License.
 
-#### 5. Submission of Contributions
+### 5. Submission of Contributions
 
 Unless You explicitly state otherwise, any Contribution intentionally submitted
 for inclusion in the Work by You to the Licensor shall be under the terms and
@@ -127,14 +127,14 @@ Notwithstanding the above, nothing herein shall supersede or modify the terms of
 any separate license agreement you may have executed with Licensor regarding
 such Contributions.
 
-#### 6. Trademarks
+### 6. Trademarks
 
 This License does not grant permission to use the trade names, trademarks,
 service marks, or product names of the Licensor, except as required for
 reasonable and customary use in describing the origin of the Work and
 reproducing the content of the NOTICE file.
 
-#### 7. Disclaimer of Warranty
+### 7. Disclaimer of Warranty
 
 Unless required by applicable law or agreed to in writing, Licensor provides the
 Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
@@ -145,7 +145,7 @@ solely responsible for determining the appropriateness of using or
 redistributing the Work and assume any risks associated with Your exercise of
 permissions under this License.
 
-#### 8. Limitation of Liability
+### 8. Limitation of Liability
 
 In no event and under no legal theory, whether in tort (including negligence),
 contract, or otherwise, unless required by applicable law (such as deliberate
@@ -157,7 +157,7 @@ damages for loss of goodwill, work stoppage, computer failure or malfunction, or
 any and all other commercial damages or losses), even if such Contributor has
 been advised of the possibility of such damages.
 
-#### 9. Accepting Warranty or Additional Liability
+### 9. Accepting Warranty or Additional Liability
 
 While redistributing the Work or Derivative Works thereof, You may choose to
 offer, and charge a fee for, acceptance of support, warranty, indemnity, or
@@ -170,7 +170,7 @@ accepting any such warranty or additional liability.
 
 _END OF TERMS AND CONDITIONS_
 
-### APPENDIX: How to apply the Apache License to your work
+## APPENDIX: How to apply the Apache License to your work
 
 To apply the Apache License to your work, attach the following boilerplate
 notice, with the fields enclosed by brackets `[]` replaced with your own

--- a/license-ccbysa40.md
+++ b/license-ccbysa40.md
@@ -5,7 +5,7 @@ layout: default
 
 By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
-### Section 1 – Definitions.
+## Section 1 – Definitions.
 
 a. __Adapted Material__ means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 
@@ -33,7 +33,7 @@ l. __Sui Generis Database Rights__ means rights other than copyright resulting f
 
 m. __You__ means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
 
-### Section 2 – Scope.
+## Section 2 – Scope.
 
 a. ___License grant.___
 
@@ -105,7 +105,7 @@ In addition to the conditions in Section 3(a), if You Share Adapted Material You
 
 3. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
 
-### Section 4 – Sui Generis Database Rights.
+## Section 4 – Sui Generis Database Rights.
 
 Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
 
@@ -117,7 +117,7 @@ c. You must comply with the conditions in Section 3(a) if You Share all or a sub
 
 For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
 
-### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+## Section 5 – Disclaimer of Warranties and Limitation of Liability.
 
 a. __Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.__
 
@@ -125,7 +125,7 @@ b. __To the extent possible, in no event will the Licensor be liable to You on a
 
 c. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
 
-### Section 6 – Term and Termination.
+## Section 6 – Term and Termination.
 
 a. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
 
@@ -141,13 +141,13 @@ c. For the avoidance of doubt, the Licensor may also offer the Licensed Material
 
 d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
 
-### Section 7 – Other Terms and Conditions.
+## Section 7 – Other Terms and Conditions.
 
 a. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
 
 b. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.t stated herein are separate from and independent of the terms and conditions of this Public License.
 
-### Section 8 – Interpretation.
+## Section 8 – Interpretation.
 
 a. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
 

--- a/use-cases.md
+++ b/use-cases.md
@@ -19,9 +19,9 @@ projects exist in the VM scheduling space. By comparing KubeVirt to these other
 projects, it should be clear what KubeVirt’s scope is and where it fits in the
 ecosystem.
 
-### KubeVirt vs. Other Projects
+## KubeVirt vs. Other Projects
 
-#### Kubernetes
+### Kubernetes
 
 Kubernetes is an open source project built to automate deployment and lifecycle
 management of containerized applications.
@@ -29,7 +29,7 @@ management of containerized applications.
 KubeVirt is a drop in addon that can be applied to any to Kubernetes cluster
 that gives Kubernetes the ability to manage VMs.
 
-#### OpenStack
+### OpenStack
 
 OpenStack is an open source IaaS platform built of various components to provide
 a wide range of features such as compute (VM scheduling), networking, block
@@ -43,7 +43,7 @@ projects, we hope to see KubeVirt become the widely adopted standard for
 scheduling VMs. It is theoretically possible OpenStack could adopt KubeVirt for
 VM scheduling.
 
-#### Nova
+### Nova
 
 Nova is the open source component of OpenStack responsible for VM scheduling.
 Nova provides an abstraction layer that allows multiple virtualization
@@ -57,7 +57,7 @@ focusing on this technology stack we aren’t limited by creating a one size fit
 all virtualization technology abstraction. We can fully support a feature set
 that leverages all that Libvirt and KVM have to offer.
 
-#### oVirt
+### oVirt
 
 oVirt is an open source virtualization management platform that provides VM
 scheduling, network and storage. One of the fundamental differences between
@@ -76,7 +76,7 @@ functionality desired for cloud IaaS VMs. Compared to oVirt, KubeVirt could
 replace the scheduling component of oVirt and consume network and storage from
 Kubernetes.
 
-#### Libvirt
+### Libvirt
 
 Libvirt is an open source project that provides a feature set for handling
 VM lifecycle actions (start, stop, pause, save, restore, and live migration)
@@ -90,7 +90,7 @@ functionality that libvirt already provides.  It's worth noting here that
 KubeVirt is primarily using libvirt for it's virtualization capabilities.
 Storage and network will be consumed from Kubernetes.
 
-#### AWS EC2 and Google GCE
+### AWS EC2 and Google GCE
 
 EC2 and GCE are closed source public cloud IaaS offerings provided by AWS and
 Google. This means users are locked into using datacenters and pricing models
@@ -109,7 +109,7 @@ We aim to provide the kind of feature set and flexibility that would
 allow IaaS providers to replace their underlying VM scheduling component with
 KubeVirt.
 
-### Use Cases
+## Use Cases
 
 Hopefully by understanding KubeVirt’s relationship to other projects the scope
 of KubeVirt is more obvious. KubeVirt is not trying to compete with any of


### PR DESCRIPTION
It is best practice for the main page title to be a h1.

This also makes for less confusion for people creating markup,
as they only need to expect a single heading level to have been
consumed by the layout template.

