### PR TITLE
Allow the usage of "go get -d kubevirt.io/kubevirt"

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1" />
+    <meta name="go-import" content="kubevirt.io/kubevirt git https://github.com/kubevirt/kubevirt">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>

--- a/pages/kubevirt.md
+++ b/pages/kubevirt.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: 
+permalink: /kubevirt/
+---
+
+To fetch the KubeVirt sources run `go get -d kubevirt.io/kubevirt`.


### PR DESCRIPTION
Hi,

It would be great if we could finally resolve https://github.com/kubevirt/kubevirt/issues/610.

Here is a very primitive solution to make 

```
go get -d kubevirt.io/kubevirt
```

work.

In order to make it work, it would be required that we can also hit the page with `https://kubevirt.io/kubevirt` and not just via `https://www.kubevirt.io/kubevirt`.

I am open for better suggestions.

