### PR TITLE
Rename ovm and vm

### DIFF
--- a/pages/get_kubevirt.md
+++ b/pages/get_kubevirt.md
@@ -59,19 +59,19 @@ Once you deployed KubeVirt you are ready to launch a VM:
 $ kubectl apply -f https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
 
 # After deployment you can manage VMs using the usual verbs:
-$ kubectl get ovms
-$ kubectl get ovms -o yaml testvm
+$ kubectl get vms
+$ kubectl get vms -o yaml testvm
 
 # To start an offline VM you can use
 $ ./virtctl start testvm
-$ kubectl get vms
-$ kubectl get vms -o yaml testvm
+$ kubectl get vmis
+$ kubectl get vmis -o yaml testvm
 
 # To shut it down again
 $ ./virtctl stop testvm
 
 # To delete
-$ kubectl delete vms testvm
+$ kubectl delete vmis testvm
 # To create your own
 $ kubectl create -f $YOUR_VM_SPEC
 ```


### PR DESCRIPTION
Change the get start with kubevirt page.

rename ovms to vms and vms to vmis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt.github.io/56)
<!-- Reviewable:end -->
