### PR TITLE
Adds go get kubevirt.io/containerized-data-importer support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1, shrink-to-fit=no" />
     <meta name="go-import" content="kubevirt.io/kubevirt git https://github.com/kubevirt/kubevirt">
+    <meta name="go-import" content="kubevirt.io/containerized-data-importer git https://github.com/kubevirt/containerized-data-importer">
     <meta name="description" content="{{ site.description }}">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 

--- a/pages/containerized-data-importer.md
+++ b/pages/containerized-data-importer.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: 
+permalink: /containerized-data-importer/
+---
+
+To fetch Containerized Data Importer sources run `go get -d kubevirt.io/containerized-data-importer`.


### PR DESCRIPTION
Enables `go get kubevirt.io/containerized-data-importer` by adding the respective meta tag and page.