### PR TITLE
Creates versions of lab6 and lab7 for Kubernetes

### DIFF
--- a/pages/labs/kubernetes/lab6/lab6.md
+++ b/pages/labs/kubernetes/lab6/lab6.md
@@ -1,0 +1,77 @@
+## Use KubeVirt
+
+### Create a Virtual Machine
+
+Download the VM manifest and explore it. Note it uses a [registry disk](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes?id=registrydisk) and as such doesn't persist data. Such registry disks currently exist for alpine, cirros and fedora.
+
+```
+wget https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+less vm.yaml
+```
+
+Apply the manifest to Kubernetes.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+  virtualmachine.kubevirt.io "testvm" created
+  virtualmachineinstancepreset.kubevirt.io "small" created
+```
+
+### Manage Virtual Machines (optional):
+
+To get a list of existing Virtual Machines. Note the `running` status.
+
+```
+kubectl get vms
+kubectl get vms -o yaml testvm
+```
+
+To start a Virtual Machine you can use:
+
+```
+./virtctl start testvm
+```
+
+Now that the Virtual Machine has been started, check the status. Note the `running` status.
+
+```
+kubectl get vms
+kubectl get vms -o yaml testvm
+```
+
+### Accessing VMs (serial console & spice)
+
+Connect to the serial console of the Cirros VM. Hit return / enter a few times and login with the displayed username and password. 
+
+```
+./virtctl console testvm
+```
+
+Disconnect from the virtual machine console by typing: `ctrl+]`.
+
+Connect to the graphical display.
+
+Note: Requires `remote-viewer` from the `virt-viewer` package. This is out of scope for this lab. 
+
+```
+./virtctl vnc testvm
+```
+
+### Controlling the State of the VM
+
+To shut it down:
+
+```
+./virtctl stop testvm
+```
+
+To delete a Virtual Machine:
+
+```
+kubectl delete vms testvm
+```
+
+This concludes this section of the lab.
+
+[Next Lab](../lab7/lab7.md)\
+[Home](../../README.md)

--- a/pages/labs/kubernetes/lab7/lab7.md
+++ b/pages/labs/kubernetes/lab7/lab7.md
@@ -1,0 +1,81 @@
+## Experiment with CDI
+
+[CDI](https://github.com/kubevirt/containerized-data-importer) is an utility designed to import Virtual Machine images for use with Kubevirt. 
+
+At a high level, a persistent volume claim (PVC) is created. A custom controller watches for importer specific claims, and when discovered, starts an import process to create a raw image named *disk.img* with the desired content into the associated PVC
+
+#### Install CDI
+
+We will first explore each component and install them. In this exercise we create a hostpath provisioner and storage class. 
+
+```
+wget https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/pages/labs/manifests/storage-setup.yml
+cat storage-setup.yml
+wget https://raw.githubusercontent.com/kubevirt/containerized-data-importer/v0.5.0/manifests/controller/cdi-controller-deployment.yaml
+cat cdi-controller-deployment.yaml
+kubectl create -f storage-setup.yml
+kubectl create -f cdi-controller-deployment.yaml
+```
+
+Review the objects that were added.
+
+```
+kubectl get pods
+```
+
+#### Use CDI
+
+As an example, we will import a Fedora28 Cloud Image as a PVC and launch a Virtual Machine making use of it.
+
+```
+kubectl create -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/pages/labs/manifests/pvc_fedora.yml
+```
+
+This will create the PVC with a proper annotation so that CDI controller detects it and launches an importer pod to gather the image specified in the *kubevirt.io/storage.import.endpoint* annotation.
+
+```
+kubectl get pvc fedora -o yaml
+kubectl get pod
+# replace with your importer pod name
+kubectl logs importer-fedora-pnbqh   # Substitute your importer-fedora pod name here.
+```
+
+Notice that the importer downloaded the publically available Fedora Cloud qcow image. Once the importer pod completes, this PVC is ready for use in kubevirt.
+
+Let's create a Virtual Machine making use of it. Review the file *vm1_pvc.yml*.
+
+```
+wget https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/pages/labs/manifests/vm1_pvc.yml
+cat ~/vm1_pvc.yml
+```
+
+We change the yaml definition of this Virtual Machine to inject the default public key of user in the cloud instance.
+
+```
+PUBKEY=`cat ~/.ssh/id_rsa.pub`
+sed -i "s%ssh-rsa.*%$PUBKEY%" vm1_pvc.yml
+kubectl create -f vm1_pvc.yml
+```
+
+This will create and start a Virtual Machine named vm1. We can use the following command to check our Virtual Machine is running and to gather its IP. You are looking for the IP address beside the `virt-launcher` pod.
+
+```
+kubectl get pod -o wide
+```
+
+Since we are running an all in one setup, the corresponding Virtual Machine is actually running on the same node, we can check its qemu process.
+
+```
+ps -ef | grep qemu | grep vm1
+```
+
+Finally, use the gathered ip to connect to the Virtual Machine, create some files, stop and restart the Virtual Machine with virtctl and check how data persists.
+
+```
+ssh fedora@VM_IP
+```
+
+This concludes this section of the lab.
+
+[Previous Lab](../lab6/lab6.md)\
+[Home](../../README.md)

--- a/pages/labs/kubernetes/lab7/lab7.md
+++ b/pages/labs/kubernetes/lab7/lab7.md
@@ -52,6 +52,8 @@ cat ~/vm1_pvc.yml
 We change the yaml definition of this Virtual Machine to inject the default public key of user in the cloud instance.
 
 ```
+# Generate a password-less SSH key using the default location.
+ssh-keygen
 PUBKEY=`cat ~/.ssh/id_rsa.pub`
 sed -i "s%ssh-rsa.*%$PUBKEY%" vm1_pvc.yml
 kubectl create -f vm1_pvc.yml

--- a/pages/labs/manifests/pvc_fedora.yml
+++ b/pages/labs/manifests/pvc_fedora.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "fedora"
+  labels:
+    app: containerized-data-importer
+  annotations:
+    kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/pages/labs/manifests/storage-setup.yml
+++ b/pages/labs/manifests/storage-setup.yml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hostpath-provisioner
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: hostpath-provisioner
+    spec:
+      containers:
+        - name: hostpath-provisioner
+          image: mazdermind/hostpath-provisioner:latest
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PV_DIR
+              value: /var/kubernetes
+
+#            - name: PV_RECLAIM_POLICY
+#              value: Retain
+          volumeMounts:
+            - name: pv-volume
+              mountPath: /var/kubernetes
+      volumes:
+        - name: pv-volume
+          hostPath:
+            path: /var/kubernetes
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostpath-provisioner
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: hostpath
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: hostpath

--- a/pages/labs/manifests/vm1_pvc.yml
+++ b/pages/labs/manifests/vm1_pvc.yml
@@ -1,0 +1,46 @@
+apiVersion: kubevirt.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  creationTimestamp: 2018-07-04T15:03:08Z
+  generation: 1
+  labels:
+    kubevirt.io/os: linux
+  name: vm1
+spec:
+  running: true
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: disk0
+            volumeName: vm1-vol0
+          - cdrom:
+              bus: sata
+              readonly: true
+            name: cloudinitdisk
+            volumeName: cloudinitvolume
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 1024M
+      volumes:
+      - name: vm1-vol0
+        persistentVolumeClaim:
+          claimName: fedora
+      - cloudInitNoCloud:
+          userData: |
+            #cloud-config
+            hostname: vm1
+            ssh_pwauth: True
+            disable_root: false
+            ssh_authorized_keys:
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC5Qbj7vDf0uYQpeYb432g5R4YvYJaPfPA4EM4qc3lO62c7oUsWbZlZBl5neEWX41HGCIP4Zm1ybN9iiDyeIns6hg5OkU2vUGuPtV2KCAZOI7snzXeZxlrjsVMjMy/CYUlvIOAPxY4XzfzMMAJjIJni18R2PqVRI4f4SeSq3IIzpnOu2VQmqjFmmdybQY83BvBvWj6KLszAXkJk9LkZSAoktXimDBWFPQYikzZihLolRxwHzo21lXSw58D1N+6IeMudOviAte5yu6FBUN6dFYbt9dkLuH2/ONliFz/042n5UNp0wC5BLdpVwJpWqqrCVaeXBgla/gYm8YNZJIAlf8K5 kboumedh@vegeta.local
+        name: cloudinitvolume


### PR DESCRIPTION
Substituted oc commands for kubectl.

Trimmed out content that referenced content from previous labs.
* ara app references
* references to golden-images which didn't seem to be required

Included hostpath storage class setup in lab7.

Add manifests directory to hold some files that were previously in
the administrator directory in https://github.com/scollier/kubevirt-tutorial/tree/master/administrator.