### PR TITLE
Switch to using the Red Hat Privacy Policy as requested by Red Hat Ma…

### DIFF
--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,134 +1,17 @@
 ---
 layout: page
-title: Privacy Statement
+title: Privacy
 permalink: /privacy/
 order: 20
 ---
 
-## Privacy Statement for the KubeVirt Project
+# Privacy Statement for the KubeVirt Project
 
-## Scope of This Notice
-
-This Privacy Statement is intended to describe the KubeVirt Project's privacy practices and provide information about the choices you have regarding the ways in which information collected by the KubeVirt Project is used and disclosed. For convenience, the KubeVirt Project is referred to in this document as "KubeVirt".
-
-## Our Commitment to Privacy
-
-At KubeVirt, your privacy is important to us. To better protect your privacy, we have provided this Statement explaining our information practices and the choices you can make about the way your personal information is collected, used and disclosed. To make this Statement easy to find, we have linked it from our homepage and several other locations on our website and other online properties.
-
-## The Information We Collect
-
-This Privacy Statement applies to all information collected by or submitted to KubeVirt, including personal data. "Personal data" is data that can be used to identify an individual.
-
-KubeVirt collects personal data when:
-
-* you browse our web sites;
-* you contribute to the project;
-* you participate in surveys and evaluations;
-* you participate in promotions, contests or giveaways;
-* you submit questions or comments to us.
-
-KubeVirt may also collect personal data from individuals (with their consent) at conventions, trade shows and expositions.
-
-The types of personal data collected may include (but are not limited to):
-
-* your first and last name;
-* your title and your company's name;
-* your home, billing, or other physical address (including street name, name of a city or town, state/province);
-* your country code;
-* your e-mail address;
-* your telephone number;
-* any other identifier that permits KubeVirt to make physical or online contact with you;
-* any information that KubeVirt collects during direct interactions with you, including:
-  * your IRC, Slack, or other chat nickname,
-  * your language preference,
-  * your timezone,
-  * your geographic coordinates (longitude/latitude),
-  * your affiliation(s).
-
-## Publicly Available Personal Data
-
-In keeping with the open nature and spirit of KubeVirt, some personal data attached to KubeVirt accounts is made public by default, particularly:
-
-* your email address and any display name associated with your email;
-* your github handle.
-
-You may contact [our privacy team](mailto:privacy@kubevirt.io) at any time to have this data removed. Some of this public data is retained as proof of your contributions, and cannot be removed, so that we can preserve the integrity of our historical project data.
-
-## Using (Processing) Your Personal Data
-
-KubeVirt uses the personal data you provide to:
-
-* identify and authenticate you;
-* attribute data and content you produce directly and indirectly in our public-facing services;
-* answer your questions;
-* send you information;
-* for research activities, including the production of statistical reports (such aggregated information is not used to contact the subjects of the report);
-* send you surveys.
-
-We also use this personal data to provide you with information related to your account and the products or services you acquire from us, to better understand your needs and interests, to improve our service, to personalize communications, and to comply with or fulfill any contractual obligations to you. It is in KubeVirt’s legitimate business interests to provide you with the information, communications, and services you request; to create a public record of the data and content produced by KubeVirt’s services; and to maintain the integrity of that data and content for historical, scientific, and research purposes.
-
-## Sharing Your Personal Data
-
-Unless you consent, KubeVirt will never process or share the personal data you provide to us except as described below.
-
-KubeVirt may share your personal data with third parties under any of the following circumstances:
-
-* Your publicly available personal data in, as described above, is accessible by anyone unless you opt out as already described in this Privacy Statement.
-* As required to provide service, and for e-mail housing (as a consequence of uses already described in this Privacy Statement). It is in KubeVirt’s legitimate business interest to provide all users an accurate record of data and content provided by KubeVirt’s services, and to maintain the integrity of that data and content for historical, scientific, and research purposes. This data and content may include but is not limited to email, code changes, comments, and artifacts.
-* As required by law (such as responding to a valid subpoena, warrant, audit, or agency action, or to prevent fraud).
-* For research activities, including the production of statistical reports (such aggregated information is used to describe our services and is not used to contact the subjects of the report).
-
-## Receiving E-Mail
-
-KubeVirt may send you e-mail about your account, to inform you of important upcoming KubeVirt events (e.g. elections), or in response to your questions. For your protection, KubeVirt may contact you in the event that we find an issue that requires your immediate attention. KubeVirt processes your personal data in these cases to fulfill and comply with its contractual obligations to you, to provide the services you have requested, and to ensure the security of your account.
-
-## Cookies and Other Browser Information
-
-KubeVirt's online services automatically capture IP addresses. We use IP addresses to help diagnose problems with our servers, to administer our website, and to help ensure the security of your interaction with our services. Your IP address is used to help identify you and your location, in order to provide you data and content from our services as quickly as possible. It is in KubeVirt’s legitimate business interest to maximize the efficiency and effectiveness of its services for all users.
-
-As part of offering and providing customizable and personalized services, KubeVirt uses cookies to store and sometimes track information about you. A cookie is a small amount of data that is sent to your browser from a Web server and stored on your computer's hard drive. All sections of kubevirt.io where you are prompted to log in or that are customizable require your browser to accept cookies.
-
-Generally, we use cookies to:
-
-1. Remind us of who you are and to access your account information (stored on our computers) in order to provide a better and more personalized service. This cookie is set when you register or "sign in" and is modified when you "sign out" of our services.
-2. Estimate audience size. Each browser accessing KubeVirt is given a unique cookie that is used to determine the extent of repeat usage and usage by a registered user versus by an unregistered user.
-3. Measure certain traffic patterns, which areas of KubeVirt's network of websites you have visited, and your visiting patterns in the aggregate. We use this research to understand how our user's habits are similar or different from one another so that we can make each new experience on kubevirt.io a better one. We may use this information to better personalize the content, banners, and promotions you and other users will see on our sites.
-
-If you do not want your personal information to be stored by cookies, you can configure your browser so that it always rejects these cookies or asks you each time if you accept them or not. However, you must understand that the use of cookies may be necessary to provide certain services, and choosing to reject cookies will reduce the performance and functionality of the site. Your browser documentation includes instructions explaining how to enable, disable or delete cookies at the browser level (usually located in the “Help”, “Tools” or “Edit” facility).
-
-## Public Forums Reminder
-
-KubeVirt often makes chat rooms, forums, mailing lists, message boards, and/or news groups available to its users. Please remember that any information that is disclosed in these areas becomes public information. Exercise caution when deciding to disclose your personal data. Although we value individual ideas and encourage free expression, KubeVirt reserves the right to take necessary action to preserve the integrity of these areas, such as removing any posting that is vulgar or inappropriate. It is in KubeVirt’s legitimate business interests to provide all users an accurate record of data and content provided in the public forums it maintains and uses; to maintain the integrity of that data and content for historical, scientific, and research purposes; and to provide an environment for the free exchange of ideas relevant and constructive to the development and propagation of open source software.
-
-## Our Commitment to Children's Online Privacy
-
-Out of special concern for children's privacy, KubeVirt does not knowingly accept online personal information from children under the age of 13. KubeVirt does not knowingly allow children under the age of 13 to become registered members of our sites. KubeVirt does not knowingly collect or solicit personal information about children under 13.
-
-In the event that KubeVirt ever decides to expand its intended site audience to include children under the age of 13, those specific web pages will, in accordance with the requirements of the Children's Online Privacy Protection Act (COPPA), be clearly identified and provide an explicit privacy notice addressed to children under 13. In addition, KubeVirt will provide an appropriate mechanism to obtain parental approval, allow parents to subsequently make changes to or request removal of their children's personal information, and provide access to any other information as required by law.
-
-## About Links to Other Sites
-
-This site contains links to other sites. KubeVirt does not control the information collection of sites that can be reached through links from kubevirt.io. If you have questions about the data collection procedures of linked sites, please contact those sites directly.
-
-## Your Rights and Choices in the EEA
-
-Where the EU General Data Protection Regulation 2016/679 (“GDPR”) applies to the processing of your personal data, especially when you access the website from a country in the European Economic Area (“EEA”), you have the following rights, subject to some limitations, against KubeVirt:
-
-* The right to access your personal data;
-* The right to rectify the personal data we hold about you;
-* The right to erase your personal data;
-* The right to restrict our use of your personal data;
-* The right to object to our use of your personal data;
-* The right to receive your personal data in a usable electronic format and transmit it to a third party (also known as the right of data portability); and
-* The right to lodge a complaint with your local data protection authority.
-
-If you would like to exercise any of these rights, you may do so by [contacting our privacy team](mailto:privacy@kubevirt.io). Please understand, however, the rights enumerated above are not absolute in all cases.
-
-Where the GDPR applies, you also have the right to withdraw any consent you have given to uses of your personal data. If you wish to withdraw consent that you have previously provided to KubeVirt, you may do so by [contacting our privacy team](mailto:privacy@kubevirt.io). However, the withdrawal of consent will not affect the lawfulness of processing based on consent before its withdrawal.
+As Kubevirt.io and most of the infrastructure of the Kubevirt Project are currently hosted by Red Hat Inc., this site falls under the [Red Hat Privacy Policy](https://www.redhat.com/en/about/privacy-policy).  All terms of that privacy policy apply to this site.  Should we change our hosting in the future, this Privacy Policy will be updated.
 
 ## How to Contact Us
 
-If you have any questions about any of these practices or KubeVirt's use of your personal information, please feel free to [contact us](mailto:privacy@kubevirt.io).
+If you have any questions about any of these practices or KubeVirt's use of your personal information, please feel free to [contact us](mailto:privacy@kubevirt.io) or [file an Issue](https://github.com/kubevirt/kubevirt.github.io/issues) in our Github repo.
 
 KubeVirt will work with you to resolve any concerns you may have about this Statement.
 
@@ -136,4 +19,4 @@ KubeVirt will work with you to resolve any concerns you may have about this Stat
 
 KubeVirt reserves the right to change this policy from time to time. If we do make changes, the revised Privacy Statement will be posted on this site. A notice will be posted on our blog and/or mailing lists whenever this privacy statement is changed in a material way.
 
-This Privacy Statement was last amended on May 25, 2018.
+This Privacy Statement was last amended on September 6, 2018.


### PR DESCRIPTION
…rketing & Legal, partly because we're using Adobe Analytics on the Red Hat account.

Our previous privacy policy was pretty much 100% redundant with the Red Hat one -- unsurprising, since RH legal helped us write it -- so it doesn't make sense to have both.  We'll just link to the RH privacy policy, and if we move the site to CNCF-owned property someday (or anything similar) we'll change to their policy.

@scollier please review & merge.