### PR TITLE
Fix jekyll container start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Under the Community page, depending on your content settings, you will be able t
 ### Run a jekyll container
 
 ```
-sudo docker run -d --name kubevirtio -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll serve --watch
+sudo docker run -d --name kubevirtio -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve --watch
 ```
 
 ### View the site


### PR DESCRIPTION
The command was missing the "jekyll" executable and ended up trying
to execute "serve".