### PR TITLE
fix(tables): update table styling for markdown tables

### DIFF
--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -1,0 +1,20 @@
+table {
+  width: 100%;
+  margin-bottom: 1rem;
+  background-color: transparent;
+  border: 1px solid #dee2e6;
+  tr {
+    th {
+      border-bottom-width: 2px;
+    }
+  }
+  thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+  }
+  th, td {
+    padding: .75rem;
+    border: 1px solid #dee2e6;
+    vertical-align: top;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -16,6 +16,7 @@
 @import "posts";
 @import "social-feed";
 @import "inputs";
+@import "tables";
 
 @import "footer";
 


### PR DESCRIPTION
This PR updates the styling of the default markdown tables when rendered in HTML. The styling mimics the Bootstrap 4 `.table-bordered` styling that is usually applied with specifying the class.

**Example:**
![screen shot 2018-09-12 at 2 24 08 pm](https://user-images.githubusercontent.com/4032718/45445293-d2ef1180-b697-11e8-952f-966eb6d43910.png)
