### PR TITLE
Activating tests for CI/CD validation on PR/MR

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,11 @@ namespace :links do
     desc 'Checks html files looking for external dead links'
     task :test_external => :build do
         options = { 
-            :assume_extension 	=> true,
-            :only_4xx 			=> true,
-			:log_level 			=> :info,
-            :internal_domains 	=> ["https://instructor.labs.sysdeseng.com"],
-            :external_only 		=> true
+            :assume_extension   => true,
+            :only_4xx           => true,
+            :log_level          => :info,
+            :internal_domains   => ["https://instructor.labs.sysdeseng.com"],
+            :external_only      => true
         }
         puts "Checking External links..."
         HTMLProofer.check_directory("./_site", options).run
@@ -22,11 +22,11 @@ namespace :links do
 
     desc 'Checks html files looking for internal dead links'
     task :test_internal => :build do
-        options = { 
+        options = {
             :assume_extension   => true,
-            :only_4xx 		    => true,
+            :only_4xx           => true,
             :allow_hash_href    => true,
-			:log_level 			=> :info,
+            :log_level          => :info,
             :disable_external   => true
         }
         puts "Checking Internal links..."

--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,4 @@ namespace :links do
 end
 
 desc 'The default task will execute all tests in a row'
-# TODO: Waiting for merging the link fixing PR to activate the external and internal checker
-#task :default => ['links:test_external', 'links:test_internal']
-task :default => :build
+task :default => ['links:test_external', 'links:test_internal']


### PR DESCRIPTION
This PR activates the tests for broken links detector on kubevirt.io that will be triggered by TravisCI in every PR/MR.

This is the status right now:
```
➜  kubevirt.github.io git:(master) rake

Building
bundle exec jekyll build
Configuration file: /home/jparrill/ownCloud/RedHat/RedHat_Engineering/kubevirt/repos/kubevirt.github.io/_config.yml
            Source: /home/jparrill/ownCloud/RedHat/RedHat_Engineering/kubevirt/repos/kubevirt.github.io
       Destination: /home/jparrill/ownCloud/RedHat/RedHat_Engineering/kubevirt/repos/kubevirt.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
    Liquid Warning: Liquid syntax error (line 86): Expected end_of_string but found open_round in "{{ lookup('env','AWS_ACCESS_KEY') }}" in labs/ocp/appendices.md
    Liquid Warning: Liquid syntax error (line 87): Expected end_of_string but found open_round in "{{ lookup('env','AWS_SECRET_KEY') }}" in labs/ocp/appendices.md
                    done in 1.951 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
Checking External links...
Running ["ScriptCheck", "LinkCheck", "ImageCheck"] on ["./_site"] on *.html... 


Checking 567 external links...
Ran on 130 files!


HTML-Proofer finished successfully.
Checking Internal links...
Running ["ScriptCheck", "LinkCheck", "ImageCheck"] on ["./_site"] on *.html... 


Ran on 130 files!


HTML-Proofer finished successfully.
```