### PR TITLE
Change title to "Try KubeVirt on X" from "Easy Install using X"

### DIFF
--- a/pages/ec2.md
+++ b/pages/ec2.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Easy install using AWS 
+title: Try KubeVirt on AWS 
 ---
 
 We have created AWS images that automatically install Kubernetes

--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Easy Install Using GCP
+title: Try KubeVirt on GCP
 ---
 
 You can try KubeVirt in Google Cloud Platform


### PR DESCRIPTION
This makes the title consistent with the homepage where the button
states "KubeVirt on X, Try It!".

Fixes: https://github.com/kubevirt/kubevirt.github.io/issues/126