### PR TITLE
Add deprecation warning to the documentation

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -6,6 +6,13 @@ navbar_active: Docs
 order: 10
 ---
 
+# Deprecation Warning
+
+This documentation pages are outdated and we are currently working on the replacement.  In the meantime, please follow the [KubeVirt User Guide](http://kubevirt.io/user-guide).
+
+**Read it at:** http://docs.kubevirt.io
+
+
 # Introduction
 
 KubeVirt is a Kubernetes add-on to run virtual machines (VirtualMachineInstances) on a Kubernetes cluster.


### PR DESCRIPTION
Since the KubeVirt documentation pages that are part of the KubeVirt Website do not fulfill technical requirements given by the KubeVirtdevelopers, they need to be replaced by an alternative solution.  After a long discussion, we have decided for the AsciiDoc-based solution that is currently in the phase of implementation.  In the meantime, everybody should use the *KubeVirt User Guide* [1] as the only up-to-date documentation resource.  We should add at least a deprecation warning to the first page for convenience.

[1] http://kubevirt.io/user-guide
[1] http://docs.kubevirt.io