### PR TITLE
Include warning about possible conflicts with Weave IP allocation

### DIFF
--- a/pages/ec2.md
+++ b/pages/ec2.md
@@ -56,6 +56,12 @@ period. These images are not meant to be used in production.
 
 ![instance-type-memory-selection](/assets/images/kubevirt-button/ec2-instance-memory-selection.png)
 
+ * We install Weave Net as the CNI to enable pods to communicate with each
+   other in the Kubernetes cluster. We reserve the 172.30.0.0/16 IP allocation
+   range for Weave Net. Verify that the VPC you selected for "Network" in the
+   "Instance Details" screen has a CIDR that does not overlap with Weave's
+   IP allocation range. 
+
  * You will need to be able to log into your instance through SSH. Depending
    on your network configuration, you may need to enable public IP. To enable
    a public IP, in the "Instance Details" screen select "Enable" for

--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -45,6 +45,11 @@ It's recommended to select:
 
 Under "boot disk", select the image that you created above.
 
+If you are using custom networking settings, verify that the CIDR used
+by the network interfaces do not overlap with Weave Net's 172.30.0.0/16
+IP allocation range. We use Weave Net as the CNI to enable pods to communicate
+with each other in the Kubernetes cluster.
+
 Now hit "Create" to start the instance.
 
 KubeVirt along with Kubernetes will get provisioned during boot!

--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -46,7 +46,7 @@ It's recommended to select:
 Under "boot disk", select the image that you created above.
 
 If you are using custom networking settings, verify that the CIDR used
-by the network interfaces do not overlap with Weave Net's 172.30.0.0/16
+by the network interfaces does not overlap with Weave Net's 172.30.0.0/16
 IP allocation range. We use Weave Net as the CNI to enable pods to communicate
 with each other in the Kubernetes cluster.
 


### PR DESCRIPTION
Weave Net is installed by kubevirt-ansible as the CNI for pod to pod
communications. kubevirt-ansible reserves the 172.30.0.0/16 CIDR for
Weave's IP allocation range.

Both EC2 and GCP pages are updated to include information about where
conflicts could occur during instance setup.

Fixes issue https://github.com/kubevirt/kubevirt.github.io/issues/138