### PR TITLE
Kubernetes labs update 

### DIFF
--- a/labs/kubernetes/lab6.md
+++ b/labs/kubernetes/lab6.md
@@ -57,10 +57,6 @@ Connect to the serial console of the Cirros VM. Hit return / enter a few times a
 
 Disconnect from the virtual machine console by typing: `ctrl+]`.
 
-Connect to the graphical display.
-
-Note: Requires `remote-viewer` from the `virt-viewer` package. This is out of scope for this lab.
-
 ```
 ./virtctl vnc testvm
 ```

--- a/labs/manifests/pvc_fedora.yml
+++ b/labs/manifests/pvc_fedora.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
+    cdi.kubevirt.io/storage.import.endpoint: "https://fedora.mirror.constant.com/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
 spec:
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
* removed section in lab6 on using virtctl to use vnc. 
* updated CDI lab to latest version, 1.2.0
* updated pvc_fedora.yml to use updated annotation
* improved CDI lab instructions on what to do if import fails and the need to monitor VM boot to know when they can login via ssh
* updated URL to fedora image. The fedora mirror returned 404 on EC2 instance.

