### PR TITLE
Rename Kubernetes labs

### DIFF
--- a/_data/labs_toc.yml
+++ b/_data/labs_toc.yml
@@ -2,6 +2,6 @@ toc:
   - title: KubeVirt Labs
     subfolderitems:
       - page: Use KubeVirt
-        url: /labs/kubernetes/lab6
+        url: /labs/kubernetes/lab1
       - page: Experiment with CDI
-        url: /labs/kubernetes/lab7
+        url: /labs/kubernetes/lab2

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -1,7 +1,7 @@
 ---
 layout: kubernetes
 title: Use KubeVirt
-permalink: /labs/kubernetes/lab6
+permalink: /labs/kubernetes/lab1
 lab: kubernetes
 order: 1
 ---
@@ -77,5 +77,5 @@ kubectl delete vms testvm
 
 This concludes this section of the lab.
 
-[Next Lab]({{ site.baseurl }}/labs/kubernetes/lab7)\
+[Next Lab]({{ site.baseurl }}/labs/kubernetes/lab2)\
 [Home]({{ site.baseurl }}/labs.html)

--- a/labs/kubernetes/lab2.md
+++ b/labs/kubernetes/lab2.md
@@ -1,7 +1,7 @@
 ---
 layout: kubernetes
 title: Experiment with CDI
-permalink: /labs/kubernetes/lab7
+permalink: /labs/kubernetes/lab2
 lab: kubernetes
 order: 1
 ---
@@ -97,5 +97,5 @@ ssh fedora@VM_IP
 
 This concludes this section of the lab.
 
-[Previous Lab]({{ site.baseurl }}/labs/kubernetes/lab6)\
+[Previous Lab]({{ site.baseurl }}/labs/kubernetes/lab1)\
 [Home]({{ site.baseurl }}/labs.html)

--- a/pages/ec2.md
+++ b/pages/ec2.md
@@ -93,11 +93,11 @@ After you have connected to your instance through SSH, you can
 work through a couple of labs to help you get acquainted with KubeVirt
 and how to use it to create and deploy VMs with Kubernetes.
 
-The first lab is ["Use KubeVirt"](../labs/kubernetes/lab6). This lab walks you
+The first lab is ["Use KubeVirt"](../labs/kubernetes/lab1). This lab walks you
 through the creation of a Virtual Machine instance on Kubernetes and then
 shows you how to use virtctl to interact with its console.
 
-The second lab is ["Experiment with CDI"](../labs/kubernetes/lab7). This
+The second lab is ["Experiment with CDI"](../labs/kubernetes/lab2). This
 lab shows you how to use the [Containerized Data Importer](https://github.com/kubevirt/containerized-data-importer){:target="_blank"}
 (CDI) to import a VM image into a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/){:target="_blank"}
 (PVC) and then how to define a VM to make use of the PVC.  

--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -57,11 +57,11 @@ After you have connected to your instance through SSH, you can
 work through a couple of labs to help you get acquainted with KubeVirt
 and how to use it to create and deploy VMs with Kubernetes.
 
-The first lab is ["Use KubeVirt"](../labs/kubernetes/lab6). This lab walks you
+The first lab is ["Use KubeVirt"](../labs/kubernetes/lab1). This lab walks you
 through the creation of a Virtual Machine instance on Kubernetes and then
 shows you how to use virtctl to interact with its console.
 
-The second lab is ["Experiment with CDI"](../labs/kubernetes/lab7). This
+The second lab is ["Experiment with CDI"](../labs/kubernetes/lab2). This
 lab shows you how to use the [Containerized Data Importer](https://github.com/kubevirt/containerized-data-importer){:target="_blank"}
 (CDI) to import a VM image into a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/){:target="_blank"}
 (PVC) and then how to define a VM to make use of the PVC.


### PR DESCRIPTION
Renames lab6 to lab1 and lab7 to lab2 to avoid confusion as to where are
labs 1-5.

The original names came from how they were ordered in the OCP labs. The
Kubernetes labs are missing 1-5 because we don't guide users through
installation.