### PR TITLE
Add notes on getting access to kubectl

### DIFF
--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -47,9 +47,16 @@ Under "boot disk", select the image that you created above.
 
 Now hit "Create" to start the instance.
 
-KubeVirt along with Kubernetes will get provisioned during boot!
+KubeVirt along with Kubernetes will get provisioned during boot! You may have to
+wait at least 5 minutes in order for SSH to become available. Once your instance is
+ready, SSH to your EC2 instance using your private key.
 
-You can now access the instance through ssh and launch VMs.
+Then become the "centos" user, which has kubectl enabled, and verify the Kubernetes pods are up and running.
+
+```bash
+sudo su - centos
+kubectl get pods -n kube-system
+```
 
 ## Step 3: KubeVirt labs
 


### PR DESCRIPTION
GCP doesn't default to the centos user. After the user logs in, they
have to switch to the centos user to get access to kubectl.