### PR TITLE
Template labs commands into variables

### DIFF
--- a/_data/labs_kubernetes_variables.yml
+++ b/_data/labs_kubernetes_variables.yml
@@ -1,0 +1,11 @@
+use_kubevirt_lab:
+  vm_manifest: https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+  vm_name: testvm
+cdi_lab:
+  storage_setup_manifest: https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/storage-setup.yml
+  cdi_controller_manifest: https://github.com/kubevirt/containerized-data-importer/releases/download/v1.3.0/cdi-controller.yaml
+  cdi_pod_listing_command: "kubectl get pods -n kube-system"
+  pvc_name: fedora
+  pvc_manifest: https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/pvc_fedora.yml
+  vm_name: vm1
+  vm_manifest: https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/vm1_pvc.yml

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -13,14 +13,14 @@ order: 1
 Download the VM manifest and explore it. Note it uses a [registry disk](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes?id=registrydisk) and as such doesn't persist data. Such registry disks currently exist for alpine, cirros and fedora.
 
 ```bash
-wget https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+wget {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_manifest }}
 less vm.yaml
 ```
 
 Apply the manifest to Kubernetes.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+kubectl apply -f {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_manifest }}
   virtualmachine.kubevirt.io "testvm" created
   virtualmachineinstancepreset.kubevirt.io "small" created
 ```
@@ -37,14 +37,14 @@ kubectl get vms -o yaml testvm
 To start a Virtual Machine you can use:
 
 ```
-./virtctl start testvm
+./virtctl start {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_name }}
 ```
 
 Now that the Virtual Machine has been started, check the status. Note the `running` status.
 
 ```
 kubectl get vms
-kubectl get vms -o yaml testvm
+kubectl get vms -o yaml {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_name }}
 ```
 
 ### Accessing VMs (serial console)
@@ -52,7 +52,7 @@ kubectl get vms -o yaml testvm
 Connect to the serial console of the Cirros VM. Hit return / enter a few times and login with the displayed username and password.
 
 ```
-./virtctl console testvm
+./virtctl console {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_name }}
 ```
 
 Disconnect from the virtual machine console by typing: `ctrl+]`.
@@ -62,13 +62,13 @@ Disconnect from the virtual machine console by typing: `ctrl+]`.
 To shut it down:
 
 ```
-./virtctl stop testvm
+./virtctl stop {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_name }}
 ```
 
 To delete a Virtual Machine:
 
 ```
-kubectl delete vms testvm
+kubectl delete vms {{ site.data.labs_kubernetes_variables.use_kubevirt_lab.vm_name }}
 ```
 
 This concludes this section of the lab.

--- a/labs/kubernetes/lab2.md
+++ b/labs/kubernetes/lab2.md
@@ -17,9 +17,9 @@ At a high level, a PersistentVolumeClaim (PVC) is created. A custom controller w
 We will first explore each component and install them. In this exercise we create a hostpath provisioner and storage class.
 
 ```bash
-wget https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/storage-setup.yml
+wget {{ site.data.labs_kubernetes_variables.cdi_lab.storage_setup_manifest }}
 cat storage-setup.yml
-wget https://github.com/kubevirt/containerized-data-importer/releases/download/v1.2.0/cdi-controller.yaml
+wget {{ site.data.labs_kubernetes_variables.cdi_lab.cdi_controller_manifest }}
 cat cdi-controller.yaml
 kubectl create -f storage-setup.yml
 kubectl create -f cdi-controller.yaml
@@ -28,7 +28,7 @@ kubectl create -f cdi-controller.yaml
 Review the "cdi" pods that were added.
 
 ```
-kubectl get pods -n kube-system
+{{ site.data.labs_kubernetes_variables.cdi_lab.cdi_pod_listing_command }}
 ```
 
 #### Use the CDI
@@ -36,13 +36,13 @@ kubectl get pods -n kube-system
 As an example, we will import a Fedora28 Cloud Image as a PVC and launch a Virtual Machine making use of it.
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/pvc_fedora.yml
+kubectl create -f {{ site.data.labs_kubernetes_variables.cdi_lab.pvc_manifest }}
 ```
 
 This will create the PVC with a proper annotation so that CDI controller detects it and launches an importer pod to gather the image specified in the *cdi.kubevirt.io/storage.import.endpoint* annotation.
 
 ```
-kubectl get pvc fedora -o yaml
+kubectl get pvc {{ site.data.labs_kubernetes_variables.cdi_lab.pvc_name }} -o yaml
 kubectl get pod
 # replace with your importer pod name
 kubectl logs importer-fedora-pnbqh   # Substitute your importer-fedora pod name here.
@@ -50,12 +50,12 @@ kubectl logs importer-fedora-pnbqh   # Substitute your importer-fedora pod name 
 
 Notice that the importer downloaded the publicly available Fedora Cloud qcow image. Once the importer pod completes, this PVC is ready for use in kubevirt.
 
-If the importer pod completes in error, you may need to retry it or specify a different URL to the fedora cloud image. To retry, first delete the importer pod and the fedora PVC, and then recreate the fedora PVC.
+If the importer pod completes in error, you may need to retry it or specify a different URL to the fedora cloud image. To retry, first delete the importer pod and the {{ site.data.labs_kubernetes_variables.cdi_lab.pvc_name }} PVC, and then recreate the {{ site.data.labs_kubernetes_variables.cdi_lab.pvc_name }} PVC.
 
 Let's create a Virtual Machine making use of it. Review the file *vm1_pvc.yml*.
 
 ```bash
-wget https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/vm1_pvc.yml
+wget {{ site.data.labs_kubernetes_variables.cdi_lab.vm_manifest }}
 cat ~/vm1_pvc.yml
 ```
 
@@ -78,13 +78,13 @@ kubectl get pod -o wide
 Since we are running an all in one setup, the corresponding Virtual Machine is actually running on the same node, we can check its qemu process.
 
 ```
-ps -ef | grep qemu | grep vm1
+ps -ef | grep qemu | grep {{ site.data.labs_kubernetes_variables.cdi_lab.vm_name }}
 ```
 
 Wait for the Virtual Machine to boot and to be available for login. You may monitor its progress through the console. The speed at which the VM boots depends on whether baremetal hardware is used. It is much slower when nested virtualization is used, which is likely the case if you are completing this lab on an instance on a cloud provider.
 
 ```
-./virtctl console vm1
+./virtctl console {{ site.data.labs_kubernetes_variables.cdi_lab.vm_name }}
 ```
 
 Disconnect from the virtual machine console by typing: `ctrl+]`


### PR DESCRIPTION
Various parts of lab commands are templated so that we can use the
variables that feed into the templates as a source. The variables
are stored in a yaml file.

We can then use this yaml file in cloud-image-builder to create tests
for the labs. The cloud-image-builder tests can then test against
the same manifests and commands that the users go through in
completing the labs.