### PR TITLE
Blog: Announce KubeCon NA 2018 sessions

### DIFF
--- a/_posts/2018-11-26-kubevirt-at-kubecon-na.markdown
+++ b/_posts/2018-11-26-kubevirt-at-kubecon-na.markdown
@@ -1,0 +1,69 @@
+---
+layout: post
+author: xsgordon
+description: KubeVirt at KubeCon North America 2019
+navbar_active: Blogs
+pub-date: Nov 26
+pub-year: 2018
+category: news
+comments: true
+---
+
+[KubeCon + CloudNativeCon North America 2018][1] (Seattle, December 11-13) is
+rapidly approaching and promises to be another jam packed event for followers of
+cloud-native technologies.
+
+Given the increasing scope of the event we thought it might be useful to prepare
+a guide to where you are likely to find [KubeVirt][2] featured at the event.
+These sessions will provide you an opportunity not just to learn about
+KubeVirt's to turning [Kubernetes][3] into a common platform for containers and
+virtual machines, but also to meet other members of the community:
+
+* [KubeVirt Introductory Birds of a Feather (BoF) Session][4] led by Ryan
+  Hallisey, Software Engineer, [Red Hat][8] and Daniel Gonzalez Nothnagel, Cloud
+  Infrastructure Developer, [SAP][9]
+  - Tuesday, December 11 @ 10:50 AM PST
+
+* [KubeVirt Deep Dive Birds of a Feather (BoF) Session][5] led by Scott Collier,
+  Consulting Engineer, [Red Hat][8] and Vishesh Ajay Tanksale, [nVidia][10]
+  - Tuesday, December 11 @ 1:45 PM PST
+
+* [Connecting and Testing Virtual Network Topologies on Kubernetes][6] presented
+  by Gage Orsburn, Software Architect, [One Source Integrations][11] and Rich
+  Renner, Solutions Architect, [One Source Integrations][11]
+  - Tuesday, December 11 @ 2:35 PM PST
+
+* [Running VM Workloads Side by Side with Container Workloads][7] presented by
+  Sebastian Scheele, Co-founder and CEO, [Loodse][https://www.loodse.com/]
+  - Thursday, December 13 @ 10:50 AM PST
+
+As [previously announced][13] on the [kubevirt-dev][14] mailing list we will
+also be holding a users and contributors meetup on the Tuesday evening of the
+event:
+
+* Location: [Sheraton Grand, Seattle][15]
+* Date: Tuesday, December 11th
+* Time: 6:45 - 8:45 PM PST
+
+While we wont have Ice Cube, we do plan to have food, so if you plan to attend
+please [register][16] your interest so that we can cater accordingly! We look
+forward to seeing you all at the event! Don't forget to follow [kubevirt][17]
+on Twitter for updates throughout!
+
+[1]: https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2018/
+[2]: https://kubevirt.io
+[3]: https://kubernetes.io
+[4]: https://sched.co/Ixrt
+[5]: https://sched.co/Ixs8
+[6]: https://sched.co/GrR9
+[7]: https://sched.co/GrYS
+[8]: https://www.redhat.com
+[9]: https://www.sap.com
+[10]: https://www.nvidia.com
+[11]: http://www.onesourceint.net/
+[12]: https://www.loodse.com/
+[13]: https://groups.google.com/forum/#!msg/kubevirt-dev/SEQ7KlWl2zU/zCkm6lOKAQAJ
+[14]: https://groups.google.com/forum/#!forum/kubevirt-dev
+[15]: https://www.marriott.com/hotels/travel/seasi-sheraton-grand-seattle/
+[16]: https://www.eventbrite.com/e/kubevirt-users-and-contributors-meetup-at-kubecon-na-2018-tickets-52961333775
+[17]: https://twitter.com/kubevirt


### PR DESCRIPTION
Announce/highlight KubeCon NA 2018 sessions related to KubeVirt and the
contributors meetup.