### PR TITLE
KubeVirt v0.13.0 updates

### DIFF
--- a/_includes/scriptlets/lab1/01_get_vm_manifest.sh
+++ b/_includes/scriptlets/lab1/01_get_vm_manifest.sh
@@ -1,1 +1,1 @@
-wget https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+wget https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/vm.yml

--- a/_includes/scriptlets/lab1/02_create_testvm.sh
+++ b/_includes/scriptlets/lab1/02_create_testvm.sh
@@ -1,1 +1,1 @@
-kubectl apply -f https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/vm.yml

--- a/_includes/scriptlets/lab2/02_get_cdi_controller_manifest.sh
+++ b/_includes/scriptlets/lab2/02_get_cdi_controller_manifest.sh
@@ -1,1 +1,1 @@
-wget https://github.com/kubevirt/containerized-data-importer/releases/download/v1.3.0/cdi-controller.yaml
+wget https://github.com/kubevirt/containerized-data-importer/releases/download/v1.5.0/cdi-controller.yaml

--- a/labs/manifests/vm.yaml
+++ b/labs/manifests/vm.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  running: false
+  template:
+    metadata:
+      labels: 
+        kubevirt.io/size: small
+        kubevirt.io/domain: testvm
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+        resources:
+          requests:
+            memory: 64M
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: kubevirt/cirros-registry-disk-demo
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userDataBase64: SGkuXG4= 

--- a/labs/manifests/vm1_pvc.yml
+++ b/labs/manifests/vm1_pvc.yml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachine
 metadata:
   creationTimestamp: 2018-07-04T15:03:08Z
@@ -20,19 +20,17 @@ spec:
           - disk:
               bus: virtio
             name: disk0
-            volumeName: vm1-vol0
           - cdrom:
               bus: sata
               readonly: true
             name: cloudinitdisk
-            volumeName: cloudinitvolume
         machine:
           type: q35
         resources:
           requests:
             memory: 1024M
       volumes:
-      - name: vm1-vol0
+      - name: disk0
         persistentVolumeClaim:
           claimName: fedora
       - cloudInitNoCloud:
@@ -43,4 +41,4 @@ spec:
             disable_root: false
             ssh_authorized_keys:
             - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC5Qbj7vDf0uYQpeYb432g5R4YvYJaPfPA4EM4qc3lO62c7oUsWbZlZBl5neEWX41HGCIP4Zm1ybN9iiDyeIns6hg5OkU2vUGuPtV2KCAZOI7snzXeZxlrjsVMjMy/CYUlvIOAPxY4XzfzMMAJjIJni18R2PqVRI4f4SeSq3IIzpnOu2VQmqjFmmdybQY83BvBvWj6KLszAXkJk9LkZSAoktXimDBWFPQYikzZihLolRxwHzo21lXSw58D1N+6IeMudOviAte5yu6FBUN6dFYbt9dkLuH2/ONliFz/042n5UNp0wC5BLdpVwJpWqqrCVaeXBgla/gYm8YNZJIAlf8K5 kboumedh@vegeta.local
-        name: cloudinitvolume
+        name: cloudinitdisk


### PR DESCRIPTION
* Updated apiVersion and volume naming in vm1_pvc.yml.
* Creates a copy of the demo/vm.yaml file here so that new changes to the demo vm doesn't break users who are using an older version of KubeVirt.
* Updates CDI to v1.5.0.