### PR TITLE
create groovy library for cloud CLI objects

### DIFF
--- a/src/com/redhat/awscli/Image.groovy
+++ b/src/com/redhat/awscli/Image.groovy
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+package com.redhat.awscli;
+
+class Image {
+
+    def pipeline
+
+    String Architecture
+    String CreationDate
+    String ImageId
+    String ImageLocation
+    String ImageType
+    boolean Public
+    String OwnerId
+    String State
+    String BlockDeviceMappings
+    String Description
+    boolean EnaSupport
+    String Hypervisor
+    String Name
+    String RootDeviceName
+    String RootDeviceType
+    String SriovNetSupport
+    String VirtualizationType
+    
+    public static Image[] queryByName(String pattern, pipeline) {
+        def query = "aws ec2 describe-images --filter Name=name,Values=\"${pattern}\""
+        pipeline.echo "Query: ${query}"
+        def imageJson = pipeline.sh(
+            returnStdout: true,
+            script: query
+        )
+     
+        def imagesObject = pipeline.readJSON text: imageJson
+
+        Image[] imageList = []
+        imagesObject.Images.each{
+            Image image = new Image(it)
+            image.pipeline = pipeline
+            imageList += image
+        }
+        Image[] sortedList = imageList.sort{ a, b ->
+            return (a.CreationDate < b.CreationDate ? a : b)
+        }
+        return sortedList
+    }
+}

--- a/src/com/redhat/awscli/Instance.groovy
+++ b/src/com/redhat/awscli/Instance.groovy
@@ -1,0 +1,113 @@
+#!/usr/bin/env groovy
+package com.redhat.awscli;
+
+class Instance {
+
+    def pipeline
+
+    int AmiLaunchIndex
+    String ImageId
+    String InstanceId
+    String InstanceType
+    String KeyName
+    String LaunchTime
+    def Monitoring
+    def Placement
+    String PrivateDnsName
+    String PrivateIpAddress
+    def ProductCodes
+    String PublicDnsName
+    String PublicIpAddress
+    def State
+    String StateReason
+    String StateTransitionReason
+    String SubnetId
+    String VpcId
+    String Architecture
+    def BlockDeviceMappings
+    String ClientToken
+    boolean EbsOptimized
+    boolean EnaSupport
+    String Hypervisor
+    def NetworkInterfaces
+    String RootDeviceName
+    String RootDeviceType
+    def SecurityGroups
+    boolean SourceDestCheck
+    def Tags
+    String VirtualizationType
+    def CpuOptions
+
+    static public queryById(String instanceId, pipeline) {
+        def instanceJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-instances --instance-id ${instanceId}"
+        )
+
+        def instanceObjects = pipeline.readJSON text: instanceJson
+
+        def instances = []
+        instanceObjects.Reservations[0].Instances.each{
+            Instance instance = new Instance(it)
+            instance.pipeline = pipeline
+            instances << instance
+        }
+        return instances[0]
+    }
+    
+    static public create(String imageId, String subnetId, String groupId, String keyName, pipeline) {
+
+        def blockDeviceSpec = "'DeviceName=/dev/sda1,Ebs={DeleteOnTermination=true,VolumeSize=32,VolumeType=gp2}'"
+
+        def instanceJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 run-instances --image-id ${imageId} --instance-type t2.large --instance-initiated-shutdown-behavior terminate --block-device-mappings ${blockDeviceSpec} --key-name ${keyName}  --security-group-ids ${groupId} --subnet-id ${subnetId} --tag-specifications  'ResourceType=instance,Tags=[{Key=Name,Value=${keyName}}]'"
+        )
+
+        def instanceList = pipeline.readJSON text: instanceJson
+        def instance = new Instance(instanceList.Instances[0])
+        instance.pipeline = pipeline
+        return instance
+    }
+
+
+    def refresh() {
+        def iJson = this.pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-instances --instance-id ${this.InstanceId}"
+        )
+
+        def iObjects = this.pipeline.readJSON text: iJson
+
+        // check for length != 1
+        def instance = iObjects.Reservations[0].Instances[0]
+        instance.each{
+            key, value -> this[key] = value
+        }
+    }
+
+    def terminate() {
+        pipeline.sh(
+            "aws ec2 terminate-instances --instance-id ${this.InstanceId}"
+        )
+    }
+
+    def getStatus() {
+        def statusJson = this.pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-instance-status --instance-id ${this.InstanceId}"
+        )
+
+        def status = this.pipeline.readJSON text: statusJson
+
+        return status.InstanceStatuses[0]
+    }
+
+    def sshStatus(String command) {
+        int statusCode = this.pipeline.sh(
+                returnStatus: true,
+                script: "ssh -o StrictHostKeyChecking=no centos@${this.PublicDnsName} ${command}"
+            )
+        return statusCode
+    }
+}

--- a/src/com/redhat/awscli/InternetGateway.groovy
+++ b/src/com/redhat/awscli/InternetGateway.groovy
@@ -1,0 +1,84 @@
+#!/usr/bin/env groovy
+package com.redhat.awscli;
+
+class InternetGateway {
+
+    def pipeline
+
+    List Attachments
+    String InternetGatewayId
+    List Tags
+
+    static def queryById(String gwId, pipeline) {
+        def gwJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-internet-gateways --internet-gateway-id ${gwId}"
+        )
+
+        def gwObjects = pipeline.readJSON text: gwJson
+        def gateways = []
+        gwObjects.InternetGateways.each{
+            InternetGateway gw = new InternetGateway(it)
+            gw.pipeline = pipeline
+            gateways << gw
+        }
+        return gateways[0]
+    }
+
+    static def queryByVpcId(String vpcId, pipeline) {
+        def gwJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-internet-gateways --filters Name=attachment.vpc-id,Values=${vpcId}"
+        )
+
+        def gwObjects = pipeline.readJSON text: gwJson
+        def gateways = []
+        gwObjects.InternetGateways.each{
+            InternetGateway gw = new InternetGateway(it)
+            gw.pipeline = pipeline
+            gateways << gw
+        }
+        return gateways
+    }
+
+    static def create(pipeline) {
+        def gwJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 create-internet-gateway"
+        )
+
+        def gwObject = pipeline.readJSON text: gwJson 
+        def gateway = new InternetGateway(gwObject.InternetGateway)
+        gateway.pipeline = pipeline
+
+        return gateway
+    }
+
+    def delete() {
+        this.pipeline.sh(
+            script: "aws ec2 delete-internet-gateway --internet-gateway-id ${this.InternetGatewayId}"
+        )
+    }
+
+    def setName(String name) {
+        this.pipeline.sh(
+            script: "aws ec2 create-tags --resources ${this.InternetGatewayId} --tags Key=Name,Value=\"${name}\""
+        )
+        
+        // find the tag with Key="Name"
+        // Update the value
+        // this.Tags[]
+    }
+
+    def attach(String VpcId) {
+        this.pipeline.sh(
+            script: "aws ec2 attach-internet-gateway --internet-gateway-id ${this.InternetGatewayId} --vpc-id ${VpcId}"
+        )
+    }
+
+    def detach(String VpcId) {
+        this.pipeline.sh(
+            script: "aws ec2 detach-internet-gateway --internet-gateway-id ${this.InternetGatewayId} --vpc-id ${VpcId}"
+        )
+    }
+}

--- a/src/com/redhat/awscli/RouteTable.groovy
+++ b/src/com/redhat/awscli/RouteTable.groovy
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+package com.redhat.awscli;
+
+class RouteTable {
+    def pipeline
+
+    List Associations
+    List PropagatingVgws
+    String RouteTableId
+    List Routes
+    List Tags
+    String VpcId
+
+    static def queryById(String RouteTableId, pipeline) {
+        def rtJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-route-tables --route-table-id ${RouteTableId}"
+        )
+        def rtObjects = pipeline.readJSON text: rtJson
+
+        def rtList = []
+        rtObjects.RouteTables.each{
+            RouteTable rt = new RouteTable(it)
+            rt.pipeline = pipeline
+            rtList << rt
+        }
+        return rtList
+    }
+
+    static def queryByVpcId(String VpcId, pipeline) {
+        def rtJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-route-tables --filter Name=vpc-id,Values=${VpcId}"
+        )
+
+        def rtObjects = pipeline.readJSON text: rtJson
+
+        def rtList = []
+        rtObjects.RouteTables.each{
+            RouteTable rt = new RouteTable(it)
+            rt.pipeline = pipeline
+            rtList << rt
+        }
+        return rtList        
+    }
+
+    def refresh() {
+        def rtJson = this.pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-route-tables --route-table-id ${this.RouteTableId}"
+        )
+
+        def rtObjects = this.pipeline.readJSON text: rtJson
+
+        // check for length != 1
+        def rt = rtObjects.RouteTables[0]
+
+        rt.each{
+            key, value -> this[key] = value
+        }
+    }
+
+    def createRoute(String cidrDest, String igwId) {
+        this.pipeline.sh(
+            script: "aws ec2 create-route --route-table-id ${this.RouteTableId} --gateway-id ${igwId} --destination-cidr-block ${cidrDest}"
+        )
+    }
+
+    def deleteRoute(String cidrDest) {
+        this.pipeline.sh(
+            script: "aws ec2 delete-route --route-table-id ${this.RouteTableId} --destination-cidr-block ${cidrDest}"
+        )
+    }
+
+    def associateSubnet(String SubnetId) {
+        def respJson = this.pipeline.sh(
+            script: "aws ec2 associate-route-table --route-table ${this.RouteTableId} --subnet-id ${SubnetId}"
+        )
+    }
+
+    def disassociateSubnet(String SubnetId) {
+        def respJson = this.pipeline.sh(
+            script: "aws ec2 disassociate-route-table --association-id ${this.RouteTableAssocationId}"
+        )
+    }
+}

--- a/src/com/redhat/awscli/SecurityGroup.groovy
+++ b/src/com/redhat/awscli/SecurityGroup.groovy
@@ -1,0 +1,76 @@
+#!/usr/bin/env groovy
+package com.redhat.awscli;
+
+class SecurityGroup {
+
+    String Description
+    String GroupName
+    List IpPermissions
+    String OwnerId
+    String GroupId
+    List IpPermissionsEgress
+    String VpcId
+
+    def pipeline
+
+    static def queryById(String groupId, pipeline) {
+        def sgJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-security-groups --group-id ${groupId}"
+        )
+        def sgObjects = pipeline.readJSON text: sgJson
+        def groups = []
+        sgObjects.SecurityGroups.each{
+            SecurityGroup sg = new SecurityGroup(it)
+            sg.pipeline = pipeline
+            groups << sg
+        }
+        return groups[0]
+    }
+
+    static def queryByVpcId(String vpcId, pipeline) {
+        def sgJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-security-groups --filter 'Name=vpc-id,Values=${vpcId}'"
+        )
+        def sgObjects = pipeline.readJSON text: sgJson
+        def groups = []
+        sgObjects.SecurityGroups.each{
+            SecurityGroup sg = new SecurityGroup(it)
+            sg.pipeline = pipeline
+            groups << sg
+        }
+        return groups
+    }
+
+    static def create(String name, String description, String vpcId, pipeline) {
+        def sgIdJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 create-security-group --group-name \"${name}\" --description \"${description}\" --vpc-id ${vpcId}"
+        )
+        def sgId = pipeline.readJSON text: sgIdJson
+
+        def sgJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-security-groups --group-id ${sgId.GroupId}"
+        )
+
+        def sgObject = pipeline.readJSON text: sgJson
+        sgObject.SecurityGroups[0]
+        SecurityGroup group = new SecurityGroup(sgObject.SecurityGroups[0])
+        group.pipeline = pipeline
+        return group
+    }
+
+    def delete() {
+        this.pipeline.sh(
+            script: "aws ec2 delete-security-group --group-id ${this.GroupId}"
+        )
+    }
+
+    def authorizeIngress(String Protocol, int Port, String CidrMask) {
+        this.pipeline.sh(
+            script: "aws ec2 authorize-security-group-ingress --group-id ${this.GroupId} --protocol ${Protocol} --port ${Port} --cidr ${CidrMask}"
+        )        
+    }
+}

--- a/src/com/redhat/awscli/Subnet.groovy
+++ b/src/com/redhat/awscli/Subnet.groovy
@@ -1,0 +1,113 @@
+#!/usr/bin/env groovy
+
+package com.redhat.awscli;
+
+class Subnet {
+    def pipeline
+    String AvailabilityZone
+    int AvailableIpAddressCount
+    String CidrBlock
+    boolean DefaultForAz
+    boolean MapPublicIpOnLaunch
+    String State
+    String SubnetId
+    List Tags
+    String VpcId
+    boolean AssignIpv6AddressOnCreation
+    List Ipv6CidrBlockAssociationSet
+
+    static def queryById(String subnetId, pipeline) {
+        def subnetJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-subnets --subnet-id ${subnetId}"
+        )
+
+        def subnetObjects = pipeline.readJSON text: subnetJson
+
+        def subnets = []
+        subnetObjects.Subnets.each{
+            Subnet subnet = new Subnet(it)
+            subnet.pipeline = pipeline
+            subnets << subnet
+        }
+        return subnets[0]
+    }
+
+    static def queryByVpcId(String vpc_id, pipeline) {
+        def subnetJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-subnets --filter Name=vpc-id,Values=${vpc_id}"
+        )
+
+        def subnetObjects = pipeline.readJSON text: subnetJson
+
+        def subnets = []
+        subnetObjects.Subnets.each{
+            Subnet subnet = new Subnet(it)
+            subnet.pipeline = pipeline
+            subnets << subnet
+        }
+        return subnets
+    }
+
+    static def create(String vpcId, String cidrBlock, pipeline) {
+        def subnetJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 create-subnet --vpc-id ${vpcId} --cidr-block ${cidrBlock}"
+        )
+        def subnetObject = pipeline.readJSON text: subnetJson
+        Subnet subnet = new Subnet(subnetObject.Subnet)
+        subnet.pipeline = pipeline
+        return subnet
+    }
+
+    def delete() {
+        this.pipeline.sh(
+            script: "aws ec2 delete-subnet --subnet-id ${this.SubnetId}"
+        )
+    }
+
+    def refresh() {
+        def subnetJson = this.pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-subnetss --subnet-id ${this.SubnetId}"
+        )
+
+        def subnetObjects = this.pipeline.readJSON text: subnetJson
+
+        // check for length != 1
+        def subnet = subnetObjects.Subnets[0]
+
+        this.AvailabilityZone = subnet.AvailabilityZone
+        this.AvailableIpAddressCount = subnet.AvailableIpAddressCount
+        this.CidrBlock = subnet.CidrBlock
+        this.DefaultForAz = subnet.DefaultForAz
+        this.MapPublicIpOnLaunch = subnet.MapPublicIpOnLaunch
+        this.State = subnet.State
+
+        this.VpcId = subnet.VpcId
+        this.AssignIpv6AddressOnCreation = subnet.AssignIpv6AddressOnCreation
+        this.Ipv6CidrBlockAssociationSet = subnet.Ipv6CidrBlockAssociationSet
+    }
+
+
+    def setName(String name) {
+        this.pipeline.sh(
+            script: "aws ec2 create-tags --resources ${this.SubnetId} --tags Key=Name,Value=\"${name}\""
+        )
+        // find the tag with Key="Name"
+        // Update the value
+        // this.Tags[]
+    }
+
+    def setMapPublicIpOnLaunch(boolean MapPublicIpOnLaunch) {
+        def disable = ""
+        if (!MapPublicIpOnLaunch) {
+            disable = "no-"
+        }
+        this.pipeline.sh(
+            script: "aws ec2 modify-subnet-attribute --subnet-id ${this.SubnetId} --${disable}map-public-ip-on-launch"
+
+        )
+    }
+}

--- a/src/com/redhat/awscli/Vpc.groovy
+++ b/src/com/redhat/awscli/Vpc.groovy
@@ -1,0 +1,93 @@
+#!/usr/env/bin groovy
+package com.redhat.awscli;
+
+// ===========================================================================
+//
+// Model operations on an AWS VPC Object
+//
+// This is a VERY NAIVE interpretation
+// ===========================================================================
+
+class Vpc {
+
+    // Properties and Attributes
+    def pipeline
+    String VpcId
+    String InstanceTenancy
+    def Tags
+    def CidrBlockAssociationSet
+    def Ipv6CidrBlockAssociationSet
+    String State
+    String DhcpOptionsId
+    String CidrBlock
+    boolean IsDefault
+
+    // Queries
+
+    static def queryById(String vpc_id, pipeline) {
+        def vpcJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-vpcs --vpc-id ${vpc_id}")
+        def vpcObjects = pipeline.readJSON text: vpcJson
+
+        def vpcs = []
+        vpcObjects.Vpcs.each{
+            Vpc vpc = new Vpc(it)
+            vpc.pipeline = pipeline
+            vpcs << vpc
+        }
+        // TODO: check for empty or more than 1
+        return vpcs[0]
+    }
+    
+    static def queryByName(String name, pipeline) {
+        def vpcJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-vpcs --filters Name=tag:Name,Values='${name}'")
+        def vpcObjects = pipeline.readJSON text: vpcJson
+
+        def vpcs = []
+        vpcObjects.Vpcs.each{
+            Vpc vpc = new Vpc(it)
+            vpc.pipeline = pipeline
+            vpcs << vpc
+        }
+        return vpcs
+    }
+
+    static def create(String cidrBlock, pipeline) {
+        def vpcJson = pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 create-vpc --cidr-block ${cidrBlock}"
+        )
+        def vpcObject = pipeline.readJSON text: vpcJson
+        Vpc vpc = new Vpc(vpcObject.Vpc)
+        vpc.pipeline = pipeline
+        return vpc
+    }
+
+    // this needs to test for success and flag
+    def delete() {
+        this.pipeline.sh(
+            script: "aws ec2 delete-vpc --vpc-id ${this.VpcId}"
+        )
+    }
+
+    def setName(String name) {
+        this.pipeline.sh(
+            script: "aws ec2 create-tags --resources ${this.VpcId} --tags Key=Name,Value=\"${name}\""
+        )
+        // find the tag with Key="Name"
+        // Update the value
+        // this.Tags[]
+    }
+
+    def enableDnsNames() {
+        this.pipeline.sh(
+            script: "aws ec2 modify-vpc-attribute --vpc-id ${this.VpcId} --enable-dns-hostnames"
+        )
+    }
+}
+
+// allow contents access to Jenkins Pipeline steps
+// per http://www.aimtheory.com/jenkins/pipeline/continuous-delivery/2017/12/02/jenkins-pipeline-global-shared-library-best-practices.html

--- a/src/com/redhat/gcloud/Image.groovy
+++ b/src/com/redhat/gcloud/Image.groovy
@@ -1,0 +1,85 @@
+#!/usr/bin/env groovy
+
+package com.redhat.gcloud;
+
+class Image {
+
+    def pipeline
+
+    String archiveSizeBytes
+    String creationTimestamp
+    String description
+    String diskSizeGb
+    String family
+    String id
+    String kind
+    String labelFingerprint
+    String name
+    def rawDisk
+    String selfLink
+    String sourceType
+    String status
+
+    static Image convertObject(imageObject, pipeline) {
+        def image = new Image(imageObject)
+        image.pipeline = pipeline
+        
+        return image
+    }
+    
+    public static Image queryByName(String name, pipeline) {
+        def query = "gcloud --format json compute images describe ${name}"
+
+        pipeline.echo("Query: ${query}")
+
+        def imageJson = pipeline.sh(
+            returnStdout: true,
+            script: query
+        )
+        def imageObject = pipeline.readJSON text: imageJson
+        return convertObject(imageObject, pipeline)
+    }
+
+    public static Image create(String name, String gsfile, pipeline) {
+        def command =  "gcloud compute images create --format json ${name} --source-uri ${gsfile} --description 'Demo test image for kubevirt' --family centos"
+        
+        pipeline.echo("New Image - name: ${name}, file: ${gsfile}")
+        
+        def imageJson = pipeline.sh (
+            returnStdout: true,
+            script: command
+        )
+
+        def imageObject = pipeline.readJSON text: imageJson
+        // images create returns and array with a single member
+        return convertObject(imageObject[0], pipeline)
+    }
+
+    def refresh() {
+        this.pipeline.echo "refreshing image"
+
+        def query = "gcloud --format json compute images describe ${name}"
+
+        pipeline.echo("Query: ${query}")
+
+        def imageJson = pipeline.sh(
+            returnStdout: true,
+            script: query
+        )
+
+        def imageObject = pipeline.readJSON text: imageJson
+
+        imageObject.each{
+            key, value -> this[key] = value
+        }
+
+    }
+    
+    def delete() {
+        this.pipeline.echo "deleting image"
+
+        this.pipeline.sh (
+            "gcloud compute images delete ${this.name}"
+        )
+    }
+}

--- a/src/com/redhat/gcloud/Instance.groovy
+++ b/src/com/redhat/gcloud/Instance.groovy
@@ -1,0 +1,102 @@
+#!/usr/bin/env groovy
+package com.redhat.gcloud;
+
+class Instance {
+
+    def pipeline
+
+    boolean canIpForward
+    String cpuPlatform
+    String creationTimestamp
+    boolean deletionProtection
+    def disks
+    String id
+    String kind
+    String labelFingerprint
+    String machineType
+    def metadata
+    String name
+    def networkInterfaces
+    def scheduling
+    String selfLink
+    def serviceAccounts
+    boolean startRestricted
+    String status
+    def tags
+    String zone
+
+    static public queryByName(String name, String zone, pipeline) {
+        pipeline.echo "Getting instance ${name}"
+
+        def query = "gcloud --format json compute instances describe --zone ${zone} ${name}"
+        
+        def instanceJson = pipeline.sh(
+            returnStdout: true,
+            script: query
+        )
+
+        def instanceObject = pipeline.readJSON text: instanceJson
+
+        def instance = new Instance(instanceObject)
+        instance.pipeline = pipeline
+        
+        return instance
+    }
+
+    static public create(String name, String image, String zone, String username, String public_key, pipeline) {
+        pipeline.echo "Creating instance ${name}"
+
+        def md_value="${username}:ssh-rsa ${public_key} ${username}"
+        
+        def instanceJson = pipeline.sh(
+            returnStdout: true,
+            script: "gcloud compute instances create --format json ${name} --image ${image} --zone ${zone} --custom-cpu 2 --custom-memory 8GB --metadata ssh-keys=\"${md_value}\""
+        )
+
+        def instanceObject = pipeline.readJSON text: instanceJson
+        def instance = new Instance(instanceObject[0])
+        instance.pipeline = pipeline
+        
+        return instance
+    }
+
+    def refresh() {
+        this.pipeline.echo "refreshing image"
+        def iJson = this.pipeline.sh(
+            returnStdout: true,
+            script: "aws ec2 describe-instances --instance-id ${this.InstanceId}"
+        )
+
+        def iObject = this.pipeline.readJSON text: iJson
+
+        // check for length != 1
+        def instance = iObject
+        instance.each{
+            key, value -> this[key] = value
+        }
+    }
+
+    def delete() {
+        this.pipeline.echo "deleting image"
+        this.pipeline.sh(
+            "gcloud compute instances delete --zone ${this.zone} ${this.name}"
+        )
+    }
+
+    def getStatus() {
+        this.pipeline.echo "getting status of image"
+    }
+
+    def sshStatus(String command) {
+        int statusCode = this.pipeline.sh(
+                returnStatus: true,
+                script: "ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 centos@${this.publicIpAddress} ${command}"
+            )
+        return statusCode
+    }
+
+    String getPublicIpAddress() {
+        return this.networkInterfaces[0].accessConfigs[0].natIP
+
+    }
+}


### PR DESCRIPTION
This change creates a pair of Groovy/Jenkins libraries that can be used to create Jenkins jobs that communicate with AWS and GCP.

These make it possible to create tests for the demos that run in those cloud providers.