### PR TITLE
Create demo test YAML specifications for lab1 and lab2

### DIFF
--- a/_includes/scriptlets/lab1/05_verify_testvm_instance.sh
+++ b/_includes/scriptlets/lab1/05_verify_testvm_instance.sh
@@ -1,2 +1,2 @@
-kubectl get vms
-kubectl get vms -o yaml testvm
+kubectl get vmis
+kubectl get vmis -o yaml testvm

--- a/_includes/scriptlets/lab1/test_spec.yaml
+++ b/_includes/scriptlets/lab1/test_spec.yaml
@@ -1,6 +1,7 @@
 test:
   name: Lab One
   url: https://kubevirt.io/labs/kubernetes/lab1
+  source: ../../../labs/kubernetes/lab1.md
   requirements:
     - file:
         path: "./virtctl"

--- a/_includes/scriptlets/lab1/test_spec.yaml
+++ b/_includes/scriptlets/lab1/test_spec.yaml
@@ -1,0 +1,75 @@
+test:
+  name: Lab One
+  url: https://kubevirt.io/labs/kubernetes/lab1
+  requirements:
+    - file:
+        path: "./virtctl"
+        present: true
+        executable: true
+    - command:
+        name: kubectl
+        test: kubectl get pods --namespace kube-system
+
+  steps:
+    - step: 1
+      name: Get Kubevirt VM Manifest
+      filename: "01_get_vm_manifest.sh"
+      test: "test -f vm.yaml"
+      stdout: "‘vm.yaml’ saved"
+      revert: "rm ./vm.yaml"
+
+    - step: 2
+      name: Create a test VM
+      filename: "02_create_testvm.sh"
+      test: "kubectl get -o json vms testvm"
+      stdout: "virtualmachine.kubevirt.io/testvm created"
+      revert: "kubectl delete vms testvm"
+
+    - step: 3
+      name: Verify the test VM
+      filename: "03_verify_testvm.sh"
+      stdout: ""
+      
+    - step: 4
+      name: Start the test VM
+      filename: "04_start_testvm.sh"
+      test: "kubectl get vmis testvm"
+      revert: "virtctl stop testvm"
+      wait_for:
+        poll: "kubectl -o json get vmis testvm | jq --raw-output '.status.phase'"
+        match: "Running"
+        rate: 10
+        tries: 18
+
+    - step: 5
+      name: Verify that the test VM instance is running
+      filename: "05_verify_testvm_instance.sh"
+      stdout: ""
+
+    - step: 6
+      name: Connect to the test VM console
+      filename: "06_connect_to_testvm_console.sh"
+      expect:
+        - send: "\n"
+          expect: "testvm login:"
+          timeout: 10
+          tries: 12
+
+    - step: 7
+      name: Stop the test VM
+      filename: "07_stop_testvm.sh"
+      test: false
+      revert: "virtctl start testvm"
+      wait_for:
+        poll: "kubectl get vmis testvm"
+        match: ".*NotFound.*"
+        rate: 10
+        tries: 12
+
+    - step: 8
+      name: Delete the test VM
+      filename: "08_delete_testvm.sh"
+      test: "! kubectl get vms testvm"
+      
+  cleanup:
+    - rm vm.yaml

--- a/_includes/scriptlets/lab2/test_spec.yaml
+++ b/_includes/scriptlets/lab2/test_spec.yaml
@@ -1,0 +1,86 @@
+test:
+  name: Lab Two
+  url: https://kubevirt.io/labs/kubernetes/lab2
+  requirements:
+    - file:
+        path: "./virtctl"
+        present: true
+        executable: true
+    - command:
+        name: kubectl
+        test: kubectl get pods --namespace kube-system
+
+  steps:
+    - step: 1
+      name: Get Storage Setup Manifest
+      filename: "01_get_storage_manifest.sh"
+      test: "test -f storage-setup.yml"
+      stdout: "‘storage-setup.yml’ saved"
+      revert: "rm ./storage-setup.yml"
+
+    - step: 2
+      name: Get CDI Controller Manifest
+      filename: "02_get_cdi_controller_manifest.sh"
+      test: "test -f cdi-controller.yaml"
+      stdout: "‘cdi-controller.yaml’ saved"
+      revert: "rm ./cdi-controller.yaml"
+
+    - step: 3
+      name: Create Storage
+      filename: "03_create_storage.sh"
+      test: "kubectl get pods --namespace kube-system storage-provisioner"
+      # revert:
+      stdout: |
+        deployment.extensions/hostpath-provisioner created
+        clusterrole.rbac.authorization.k8s.io/hostpath-provisioner created
+        clusterrolebinding.rbac.authorization.k8s.io/hostpath-provisioner created
+        storageclass.storage.k8s.io/hostpath created
+      wait_for:
+        poll: "kubectl get pods --namespace kube-system storage-provisioner -o json | jq --raw-output '.status.phase'"
+        match: 'Running'
+        rate: 5
+        tries: 12
+
+    - step: 4
+      name: Create CDI Controller
+      filename: "04_create_cdi-controller.sh"
+      test: false
+      wait_for:
+        poll: "kubectl get pods --namespace kube-system | grep cdi- | grep Running | wc -l"
+        match: "3"
+        rate: 5
+        tries: 12
+      stdout: |        
+        customresourcedefinition.apiextensions.k8s.io/datavolumes.cdi.kubevirt.io created
+        clusterrolebinding.rbac.authorization.k8s.io/cdi-sa created
+        clusterrole.rbac.authorization.k8s.io/cdi created
+        clusterrolebinding.rbac.authorization.k8s.io/cdi-apiserver created
+        clusterrole.rbac.authorization.k8s.io/cdi-apiserver created
+        clusterrolebinding.rbac.authorization.k8s.io/cdi-apiserver-auth-delegator created
+        serviceaccount/cdi-apiserver created
+        rolebinding.rbac.authorization.k8s.io/cdi-apiserver created
+        role.rbac.authorization.k8s.io/cdi-apiserver created
+        rolebinding.rbac.authorization.k8s.io/cdi-extension-apiserver-authentication created
+        role.rbac.authorization.k8s.io/cdi-extension-apiserver-authentication created
+        service/cdi-api created
+        deployment.apps/cdi-apiserver created
+        serviceaccount/cdi-sa created
+        deployment.apps/cdi-deployment created
+        service/cdi-uploadproxy created
+        deployment.apps/cdi-uploadproxy created
+
+    # - step: 5
+    #   name: "View CDI Pod Status"
+    #   filename: "05_view_cdi_pod_status.sh"
+    #   test: false
+
+    # - step: 6
+    #   name: "Create Fedora Cloud Instance"
+    #   filename: "06_create_fedora_cloud_instance.sh"
+    #   test: false
+    #   stdout: |
+    #     persistentvolumeclaim/fedora created
+      
+  cleanup:
+    - rm storage-setup.yml
+    - rm cdi-controller.yaml

--- a/_includes/scriptlets/lab2/test_spec.yaml
+++ b/_includes/scriptlets/lab2/test_spec.yaml
@@ -1,6 +1,7 @@
 test:
   name: Lab Two
   url: https://kubevirt.io/labs/kubernetes/lab2
+  source: ../../../labs/kubernetes/lab2.md
   requirements:
     - file:
         path: "./virtctl"


### PR DESCRIPTION
This change creates a test specification for the lab1 and lab2 demos.  It is suitable for use with the run-scripts.py script from PR196 and the remote-demo-test.sh shell script also from PR196.

These specs define a set of steps to execute to verify the contents of the demo web pages.