### PR TITLE
Correct variable in deploy script

### DIFF
--- a/_includes/scriptlets/get_kubevirt/02_deploy_kubevirt.sh
+++ b/_includes/scriptlets/get_kubevirt/02_deploy_kubevirt.sh
@@ -1,2 +1,2 @@
 export VERSION={{ site.kubevirt_version }}
-kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT}/kubevirt-cr.yaml
+kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml


### PR DESCRIPTION
This change updates the deploy section of get_kubevirt to use the correct variable created in the previous step.