### PR TITLE
issue205: Add redirect for get_kubevirt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "jekyll"
 gem "jekyll-paginate"
+gem "jekyll-redirect-from"
 gem "html-proofer"
 gem "jekyll-asciidoc"

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ collections:
     output: true
     permalink: /:collection/:path
 
-plugins: [jekyll-paginate, jekyll-asciidoc]
+plugins: [jekyll-paginate, jekyll-asciidoc, jekyll-redirect-from]
 paginate: 5
 paginate_path: "/blogs/page:num"
 

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -2,6 +2,7 @@
 layout: page
 title: KubeVirt Quickstart with Minikube
 permalink: /quickstart_minikube/
+redirect_from: "/get_kubevirt/"
 order: 2
 ---
 


### PR DESCRIPTION
* Add redirect-from to quickstart_minikube.md
* Add jekyll-redirect-from to both jekyll config and Gemfile
* Fix #205