### PR TITLE
Have blog titles be links in /blogs/

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -43,7 +43,7 @@ order: 4
       <ul class="posts">
         {% for post in paginator.posts %}
           <li>
-            <h2 href="{{ post.url | prepend: site.baseurl }}" class="posts-title">{{ post.title }}</h2>
+            <h2 class="posts-title"><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h2>
             <div class="posts-date">{{ post.pub-date }}, {{ post.pub-year }}</div>
             {{ post.description | strip_html | truncatewords:50 }}
             {% capture readmorelink %}


### PR DESCRIPTION
They're not right now and it's expected ui on a blog.