### PR TITLE
Fix font size on blog post headers

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -81,6 +81,10 @@ a {
   }
 }
 
+h2 a {
+  font-size: 1.714rem;
+}
+
 ul,
 ol {
   font-size: 1rem;


### PR DESCRIPTION
#219 caused the font size of headers to be smaller (applying the link's settings).

Now that they contain links, this should specify their correct size again.