### PR TITLE
cdi is now in its own namespace apparently

### DIFF
--- a/_includes/scriptlets/lab2/05_view_cdi_pod_status.sh
+++ b/_includes/scriptlets/lab2/05_view_cdi_pod_status.sh
@@ -1,1 +1,1 @@
-kubectl get pods -n kube-system
+kubectl get pods -n cdi


### PR DESCRIPTION
Updating script to look at the `cdi` namespace. This script gets used at various places including the CI tests for cloud-image-builder.