### PR TITLE
[WIP] Bug: Solving error Could not find gem jekyll-sitemap gem

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "url": "https://github.com/kubevirt/kubevirt.github.ioissues"
   },
   "dependencies": {
-    "simple-jekyll-search": "^1.7.0"
+    "simple-jekyll-search": "^1.7.0",
+    "jekyll-sitemap": "^1.3.0"
+
   }
 }


### PR DESCRIPTION
In order to solve this error:

- Input
```
$ rake
```
- Output
```
Building
bundle exec jekyll build
Could not find gem 'jekyll-sitemap' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
rake aborted!
Command failed with status (7): [bundle exec jekyll build...]
/home/jparrill/ownCloud/RedHat/RedHat_Engineering/kubevirt/repos/kubevirt.github.io/Rakefile:4:in `block in <top (required)>'
Tasks: TOP => default => links:test_external => build
(See full trace by running task with --trace)
```