### PR TITLE
Fix: Future test problems on Prow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 source "https://rubygems.org"
 
 gem "jekyll"
+gem "rake"
 gem "jekyll-paginate"
 gem "jekyll-redirect-from"
 gem "html-proofer"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+#encoding: utf-8
 desc 'Generate HTML of Kubevirt.io'
 task :build do
     puts "Building"


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to solve a future problem with Prow platform testing:
```
$ bundle exec rake

Building
bundle exec jekyll build
`/` is not writable.
Bundler will use `/tmp/bundler/home/unknown' as your home directory temporarily.
Configuration file: /kubevirt/_config.yml
            Source: /kubevirt
       Destination: /kubevirt/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
    Liquid Warning: Liquid syntax error (line 112): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 198): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 353): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 377): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 389): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 405): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 431): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 446): [:dot, "."] is not a valid expression in "{{.status.podIP}}" in /kubevirt/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
    Liquid Warning: Liquid syntax error (line 86): Expected end_of_string but found open_round in "{{ lookup('env','AWS_ACCESS_KEY') }}" in labs/ocp/appendices.md
    Liquid Warning: Liquid syntax error (line 87): Expected end_of_string but found open_round in "{{ lookup('env','AWS_SECRET_KEY') }}" in labs/ocp/appendices.md
                    done in 2.614 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
Checking External links...
Running ["ImageCheck", "LinkCheck", "ScriptCheck"] on ["./_site"] on *.html... 


rake aborted!
ArgumentError: invalid byte sequence in US-ASCII
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/utils.rb:32:in `gsub'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/utils.rb:32:in `clean_content'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/utils.rb:16:in `create_nokogiri'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:95:in `check_path'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:87:in `block in process_files'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:87:in `map'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:87:in `process_files'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:68:in `check_files'
/usr/local/bundle/gems/html-proofer-3.9.2/lib/html-proofer/runner.rb:40:in `run'
/kubevirt/Rakefile:24:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => default => links:test_external
(See full trace by running task with --trace)
```

- The way to test is just:
```
git clone https://github.com/kubevirt/kubevirt.github.io.git
cd kubevirt.github.io.git
curl -L https://github.com/kubevirt/kubevirt.github.io/pull/<PR NUMBER>.patch | git am
docker run -it --name kubevirt_io -p 4000:4000 -u 1000 -v $(pwd):/kubevirt library/ruby '/bin/bash'
```

- Inside the container:
```
cd kubevirt
bundle install
bundle exec rake
```
