### PR TITLE
Fix fedora vm in lab

### DIFF
--- a/labs/manifests/vm1_pvc.yml
+++ b/labs/manifests/vm1_pvc.yml
@@ -12,10 +12,18 @@ spec:
     metadata:
       creationTimestamp: null
     spec:
+      networks:
+      - name: default
+        pod: {}
       domain:
         cpu:
           cores: 2
         devices:
+          interfaces:
+          - bridge: {}
+            name: default
+            ports:
+            - port: 22
           disks:
           - disk:
               bus: virtio


### PR DESCRIPTION
**What this PR does / why we need it**:
When I tested the lab on my Kubernetes setup using Flannel, then VM could not get a MAC address.

According to the https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html
the interface needs to be setup and defined.