### PR TITLE
Updating .qcow image URL to work around intermittent DNS issues on AWS

### DIFF
--- a/labs/manifests/pvc_fedora.yml
+++ b/labs/manifests/pvc_fedora.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "https://fedora.mirror.constant.com/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
+    cdi.kubevirt.io/storage.import.endpoint: "http://mirror.math.princeton.edu/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
 spec:
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
AWS seems to be currently having issues resolving "fedora.mirror.constant.com" so I'm taking this opportunity to change the mirror to something GCP and AWS can currently resolve and to bump the version number to 30 to track a later release (I think 28 was probably just the latest when this file was last updated).

**What this PR does / why we need it**:
This resolves a critical issue and frankly makes all your wildest dreams come true.

**Does this PR fix any issue?** 
No Github issue, no.

**Special notes for your reviewer**:

N/A