### PR TITLE
Remove EC2 reference from GCP page

### DIFF
--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -54,7 +54,7 @@ Now hit "Create" to start the instance.
 
 KubeVirt along with Kubernetes will get provisioned during boot! You may have to
 wait at least 5 minutes in order for SSH to become available. Once your instance is
-ready, SSH to your EC2 instance using your private key.
+ready, SSH to your instance using your private key.
 
 Then become the "centos" user, which has kubectl enabled, and verify the Kubernetes pods are up and running.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**

There's a reference to EC2 in the page about GCP as reported in kubevirt/cloud-image-builder#108

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes kubevirt/cloud-image-builder#108

**Special notes for your reviewer**:
