### PR TITLE
Added go-import meta data for new kubevirt/client-go repository

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1, shrink-to-fit=no" />
     <meta name="go-import" content="kubevirt.io/kubevirt git https://github.com/kubevirt/kubevirt">
+    <meta name="go-import" content="kubevirt.io/client-go git https://github.com/kubevirt/client-go">
     <meta name="go-import" content="kubevirt.io/containerized-data-importer git https://github.com/kubevirt/containerized-data-importer">
     <meta name="go-import" content="kubevirt.io/qe-tools git https://github.com/kubevirt/qe-tools">
     <meta name="go-import" content="kubevirt.io/node-recovery git https://github.com/kubevirt/node-recovery">


### PR DESCRIPTION
**What this PR does / why we need it**:
Added go-import meta data for new kubevirt/client-go repository
