### PR TITLE
Added page needed for go import of kubevirt/client-go.

### DIFF
--- a/pages/client-go.md
+++ b/pages/client-go.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: 
+permalink: /client-go/
+---
+
+To fetch the KubeVirt client-go sources run `go get -d kubevirt.io/client-go`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up to https://github.com/kubevirt/kubevirt.github.io/pull/296, forgot to create a page from which the new import will be queried by go...