### PR TITLE
Fix URL for Adobe Analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <!-- Adding Adobe Analytics -->
-    <script id="adobe_dtm" src="//www.redhat.com/dtm.js" type="text/javascript"></script>
+    <script id="adobe_dtm" src="https://www.redhat.com/dtm.js" type="text/javascript"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1, shrink-to-fit=no" >
     <meta name="go-import" content="kubevirt.io/kubevirt git https://github.com/kubevirt/kubevirt">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The header script tag that links to Adobe Analytics was missing the protocol in the URL.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #

**Special notes for your reviewer**:

I am not sure how things were even working...
