### PR TITLE
Update lab2

### DIFF
--- a/labs/manifests/storage-setup.yml
+++ b/labs/manifests/storage-setup.yml
@@ -1,11 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hostpath-provisioner
   namespace: kube-system
 spec:
   replicas: 1
-  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      k8s-app: hostpath-provisioner
   template:
     metadata:
       labels:
@@ -21,9 +23,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: PV_DIR
               value: /var/kubernetes
-
-#            - name: PV_RECLAIM_POLICY
-#              value: Retain
           volumeMounts:
             - name: pv-volume
               mountPath: /var/kubernetes

--- a/labs/manifests/vm1_pvc.yml
+++ b/labs/manifests/vm1_pvc.yml
@@ -40,5 +40,5 @@ spec:
             ssh_pwauth: True
             disable_root: false
             ssh_authorized_keys:
-            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC5Qbj7vDf0uYQpeYb432g5R4YvYJaPfPA4EM4qc3lO62c7oUsWbZlZBl5neEWX41HGCIP4Zm1ybN9iiDyeIns6hg5OkU2vUGuPtV2KCAZOI7snzXeZxlrjsVMjMy/CYUlvIOAPxY4XzfzMMAJjIJni18R2PqVRI4f4SeSq3IIzpnOu2VQmqjFmmdybQY83BvBvWj6KLszAXkJk9LkZSAoktXimDBWFPQYikzZihLolRxwHzo21lXSw58D1N+6IeMudOviAte5yu6FBUN6dFYbt9dkLuH2/ONliFz/042n5UNp0wC5BLdpVwJpWqqrCVaeXBgla/gYm8YNZJIAlf8K5 kboumedh@vegeta.local
+            - ssh-rsa YOUR_SSH_PUB_KEY_HERE
         name: cloudinitdisk


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Kubernetes 1.16 [removed extensions/v1beta Deployments](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) so the `Deployment` for the hostpath provisioner needs updating.

Taking the opportunity to remove a personal ssh key from the sample `vm1` spec.
