### PR TITLE
#issue 350 - Added storageclass hostpath to pvc and decreased the size to also work on minikube

### DIFF
--- a/labs/manifests/pvc_fedora.yml
+++ b/labs/manifests/pvc_fedora.yml
@@ -11,4 +11,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 4Gi
+  storageClassName: hostpath


### PR DESCRIPTION
…kube environments

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Need to fix the issue #350 so that hostpath is used as storageClass even there are more than one default storageClass. Also the PVC size has been decreased to 4Gi so that Fedora30 can be imported in Minikube environments with more than 4Gi of memory configured.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #350

**Special notes for your reviewer**:
I did not tested on cloud providers but on minikube


Validated on:
- [ ] Katacoda
- [x] Minikube
- [ ] AWS
- [ ] GCP