### PR TITLE
Cloud image changed from qcow2 to raw since Fedora CDN not supporting range

### DIFF
--- a/labs/manifests/pvc_fedora.yml
+++ b/labs/manifests/pvc_fedora.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2"
+    cdi.kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.raw.xz"
 spec:
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
… range

Signed-off-by: Alberto Losada <alosadag@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
Modifies pvc_fedora so the image imported is formatted as raw instead of qcow2
**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #
Solves issue #373 

**Special notes for your reviewer**:
Must be reviewed in minikube, AWS and GCP that lab2 can be finished successfully
