### PR TITLE
Modified storage class PV path to /var/lib/minikube in all labs

### DIFF
--- a/labs/manifests/storage-setup.yml
+++ b/labs/manifests/storage-setup.yml
@@ -22,14 +22,14 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: PV_DIR
-              value: /var/kubernetes
+              value: /var/lib/minikube
           volumeMounts:
             - name: pv-volume
-              mountPath: /var/kubernetes
+              mountPath: /var/lib/minikube
       volumes:
         - name: pv-volume
           hostPath:
-            path: /var/kubernetes
+            path: /var/lib/minikube
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
Alleviate the resources needed to import fedora30 cloud image when running minikube. Basically, this PR makes minikube and all cloud providers to store pv/pvs /var/lib/minikube. 

This only really applies to minikube since storage setup configuration was storing the pv in memory (tmpfs) while importing the cloud image. This was causing the VM to exhaust their resources when importing regular cloud images (~4G)

In order to keep only one storage class yaml file for the labs and same set of instructions I just modified the storage-setup.yml replacing the PV local path to a path where minikube uses persistent disk. Check [1](https://kubernetes.io/docs/setup/learning-environment/minikube/#persistent-volumes)

In case of GCP and AWS when creating the storage-setup (kubectl create -f) it will create automatically the folder (/var/lib/minikube) if it does not exist.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #393 

**Special notes for your reviewer**:
Verified on AWS and minikube 1.5.2. I guess should be verified as well when running lab in GCP. 
