### PR TITLE
Enable comments by default on articles

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,7 +46,7 @@ navbar_active: blogs
         {% endif %}
         {% include share_twitter.html text = page.title %}
 
-        {% if page.comments %}
+        {% if page.comments or page.comments == nil %}
           <div id="disqus_thread"></div>
           <script>
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Some articles doesn't have comments: true so end users cannot comment on them

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #

This enables by default comments unless blocked on individual articles

**Special notes for your reviewer**:
