### PR TITLE
Omit versions that include a dash when computing $KUBEVIRT_VERSION

### DIFF
--- a/_includes/scriptlets/quickstart_kind/02_setenv_version.sh
+++ b/_includes/scriptlets/quickstart_kind/02_setenv_version.sh
@@ -2,6 +2,6 @@
 export KUBEVIRT_VERSION="v0.25.0"
 
 # On Linux you can obtain it using 'curl' via:
-export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases|grep tag_name|sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs | cut -d'-' -f1)
+export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
 
 echo $KUBEVIRT_VERSION

--- a/_includes/scriptlets/quickstart_minikube/04_setenv_version.sh
+++ b/_includes/scriptlets/quickstart_minikube/04_setenv_version.sh
@@ -2,6 +2,6 @@
 export KUBEVIRT_VERSION="v0.18.0"
 
 # On Linux you can obtain it using 'curl' via:
-export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases|grep tag_name|sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs | cut -d'-' -f1)
+export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- - | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs)
 
 echo $KUBEVIRT_VERSION


### PR DESCRIPTION
`cut -d- -f1` will set the version to a potentially nonexistent one.
Using `grep -v -- -` instead will ignore dash-ed versions (i.e. RCs).

Signed-off-by: Jed Lejosne <jlejosne@redhat.com>