### PR TITLE
Point chat to Slack instead of IRC

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -72,14 +72,14 @@ order: 10
       </p>
     </div>
     <div class="col-sm-12 col-md-4 order-md-3 text-center">
-      <a href="https://kiwiirc.com/client/irc.freenode.net/kubevirt" target="_blank" aria-label="Chat with us on IRC">
+      <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" target="_blank" aria-label="Chat with us on Slack">
         <img src="{{ site.baseurl }}/assets/images/community-image-col3.svg" class="img-fluid" alt="Chat image">
         <h4 class="pt-3">
-          #kubevirt
+          #virtualization
         </h4>
       </a>
       <p class="pt-3">
-        Share your ideas with our engineers via our IRC channel.
+        Share your ideas in the #virtualizatio channel in Kubernetes' Slack.
       </p>
     </div>
     <div class="col-sm-12 col-md-4 order-md-1 text-center">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

We use Slack more than IRC nowadays. The README in the main kubevirt
repo was recently updated (in kubevirt/kubevirt#3024) to replace the
reference to `#kubevirt` on freenode with one to `#virtualization`
on Kubernetes Slack. This change updates the website to match that.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #

**Special notes for your reviewer**:
