### PR TITLE
Typo in slack channel name

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -79,7 +79,7 @@ order: 10
         </h4>
       </a>
       <p class="pt-3">
-        Share your ideas in the #virtualizatio channel in Kubernetes' Slack.
+        Share your ideas in the #virtualization channel in Kubernetes' Slack.
       </p>
     </div>
     <div class="col-sm-12 col-md-4 order-md-1 text-center">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

A missing `n` slipped by in #478 - this fixes it.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #

**Special notes for your reviewer**:
