### PR TITLE
Update slack link to point to the #virtualization channel

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
           <i class="fab fa-twitter fa-lg"></i>
         </a>
 
-        <a href="https://slack.k8s.io/" aria-label="Talk to us in Slack" class="link-social-slack">
+        <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" aria-label="Talk to us in Slack" class="link-social-slack">
           <i class="fab fa-slack fa-lg"></i>
         </a>
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

#472 added a link to Slack in the footer. This updates the link to point directly to the #virtualization channel instead of the generic Kubernetes Slack.

**Does this PR fix any issue?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
> Fixes #

**Special notes for your reviewer**:
