### PR TITLE
Disable default language for code formatter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,6 @@ tag_page_dir: /tag/
 kramdown:
   input: GFM
   syntax_highlighter_opts:
-    default_lang: html
     css_class: 'highlight'
     span:
       line_numbers: false


### PR DESCRIPTION
Disables HTML as the default code for formatting to avoid issues when files are included and proper language ink is not defined:

![imagen](https://user-images.githubusercontent.com/312463/75786836-2b234300-5d66-11ea-9371-591e4c15b9a1.png)


vs actual:
![imagen](https://user-images.githubusercontent.com/312463/75786875-34acab00-5d66-11ea-897b-190d3a8fa4c0.png)
