### PR TITLE
Ignore youtube links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ namespace :links do
             :assume_extension   => true,
             :only_4xx           => true,
             :log_level          => :info,
-            :internal_domains   => ["https://instructor.labs.sysdeseng.com"],
+            :internal_domains   => ["https://instructor.labs.sysdeseng.com", "https://www.youtube.com"],
             :external_only      => true,
             :url_swap           => {'https://kubevirt.io/' => '',},
         }


### PR DESCRIPTION

**What this PR does / why we need it**:

Attempt to ignore youtube links with link checker because there are repetitive 429 errors while the video can be still accessed and causes false positives
