### PR TITLE
Update the copyright line in the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 jekyll
+Copyright (c) 2020 The KubeVirt Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The LICENSE file in the website was inherited verbatim from the generator tool that is used to create the site (jekyll). However, the content in the site comes from KubeVirt contributors. As the copyright
note is about the web site content and not the tool used to generate it, it should reflect this.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
