### PR TITLE
Some issue found showing some code blocks in the "KubeVirt: installing Microsoft Windows from an ISO" blogpost

### DIFF
--- a/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
+++ b/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
@@ -87,18 +87,19 @@ To proceed with the Installation steps the different elements involved are liste
    > info "Information"
    > To upload data to the cluster, the cdi-uploadproxy service must be accessible from outside the cluster. In a production environment, this probably involves setting up an Ingress or a LoadBalancer Service.
 
-
     ```sh
     $ kubectl get services -n cdi
     NAME              TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
     cdi-api           ClusterIP   10.96.117.29   <none>        443/TCP   6d18h
     cdi-uploadproxy   ClusterIP   10.96.164.35   <none>        443/TCP   6d18h
     ```
+
     In this example the ISO file was copied to the Kubernetes node, to allow the `virtctl` to find it and to simplify the operation.
     - `--insecure`: Allow insecure server connections when using HTTPS
     - `--wait-secs`: The time in seconds to wait for upload pod to start. (default 60)
 
     The final command with the parameters and the values would look like:
+
     ```sh
     $ virtctl image-upload \
     --image-path=/root/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO \


### PR DESCRIPTION
Signed-off-by: Pedro Ibáñez <pedro@redhat.com>

**What this PR does / why we need it**:
This PR fixes the issue found in some code blocks in the blogpost "KubeVirt: installing Microsoft Windows from an ISO", the code blocks are not rendered properly and they are being shown as markdown code instead of html code.

**Special notes for your reviewer**: check if the code blocks after the sentence "To upload data to the cluster, the cdi-uploadproxy service must be accessible from outside the cluster. In a production environment, this probably involves setting up an Ingress or a LoadBalancer Service." are rendered properly or you still can see the ```sh annotations.
