### PR TITLE
Ignore 429 errors with html-proofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ namespace :links do
             :internal_domains   => ["https://instructor.labs.sysdeseng.com", "https://www.youtube.com"],
             :external_only      => true,
             :url_swap           => {'https://kubevirt.io/' => '',},
+            :http_status_ignore => [429],
         }
 
         parser = OptionParser.new


### PR DESCRIPTION

**What this PR does / why we need it**:

Ignore 429 errors which should be undefined as either failed or succeed instead of failing

