### PR TITLE
Fix link to minikube docs

### DIFF
--- a/_posts/2018-06-20-Hello-KubeVirt-on-Minikube.markdown
+++ b/_posts/2018-06-20-Hello-KubeVirt-on-Minikube.markdown
@@ -36,7 +36,7 @@ Y
 
 ## Install KVM2 driver for Minikube
 
-Minikube requires a special driver to manage Docker Machine VMs running in KVM. KVM2 is the latest iteration of the driver. Read more about it [here](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver)
+Minikube requires a special driver to manage Docker Machine VMs running in KVM. KVM2 is the latest iteration of the driver. Read more about it [here](https://minikube.sigs.k8s.io/docs/drivers/kvm2/)
 
 ```bash
 # install driver to /usr/local/bin

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -25,7 +25,7 @@ Our recommendation is to always run the latest (\*) version of
 [Minikube](https://github.com/kubernetes/minikube/){:target="\_blank"}
 available for your platform of choice, following their
 [installation instructions](https://kubernetes.io/docs/tasks/tools/install-minikube/){:target="\_blank"}. For instance, to write this guide, the **Linux** version has been used, together
-with the [**KVM2**](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver){:target="\_blank"}
+with the [**KVM2**](https://minikube.sigs.k8s.io/docs/drivers/kvm2/){:target="\_blank"}
 driver.
 
 _(\*): KubeVirt >=v0.9.2 won't run on Minikube <v0.35.0 by default because of lack of vhost-net device. (see more details at [Issue#2056](https://github.com/kubevirt/kubevirt/issues/2056))_


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The minikube documentation for the kvm2 driver changed location, causing broken links.

This fixes a couple of references to it with their new location.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
