### PR TITLE
Fix link to prow job definition

### DIFF
--- a/_posts/2019-10-31-prow-jobs-for-kubevirt.markdown
+++ b/_posts/2019-10-31-prow-jobs-for-kubevirt.markdown
@@ -50,8 +50,8 @@ For each repo we've some types of jobs:
 
 Jobs are defined in the [project-infra](https://github.com/kubevirt/project-infra/) repository, for example:
 
-- <https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml>
-- <https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml>
+- <https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml>
+- <https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml>
 
 Those jobs define the image to use (image and tag), and the commands to execute. In the examples above we're using 'Docker-in-Docker' (dind) images and we're targetting the KubeVirt-tutorial repository.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

kubevirt/project-infra#408 reorganized the project-infra repo a bit.

There's a blog post that contains links to that repo. This PR fixes these links.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

It fixes tests that are now failing for all PRs.

> Fixes #

**Special notes for your reviewer**:
