### PR TITLE
Fix link to the user guide in lab3

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -107,7 +107,6 @@
     "gcp",
     "GCP",
     "GiB",
-    "GitHub's",
     "github",
     "GitHub",
     "GitHub's",

--- a/labs/kubernetes/lab3.md
+++ b/labs/kubernetes/lab3.md
@@ -147,7 +147,7 @@ Once the PHASE will change to `Running`, we're ready for upgrading KubeVirt.
 
 #### Define the next version to upgrade to
 
-KubeVirt starting from `v0.17.0` onwards, allows to upgrade one version at a time, by using two approaches as defined in the [user-guide](https://kubevirt.io/user-guide/docs/latest/administration/intro.html#update):
+KubeVirt starting from `v0.17.0` onwards, allows to upgrade one version at a time, by using two approaches as defined in the [user-guide](https://kubevirt.io/user-guide/#/installation/updating-and-deleting-installs):
 
 - Patching the imageTag value in the KubeVirt CR spec
 - Updating the operator if no imageTag is defined (defaulting to upgrade to match the operator version)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

A link to the user guide in lab3 still had the format prior to the conversion to markdown, which resulted in a broken link.

This corrects the link to the new structure of the user guide.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

Fixes #568 

**Special notes for your reviewer**:

There's also a one-line correction in the spell checker dictionary to remove a duplicate entry, not worth a separate PR
