### PR TITLE
Add new kubevirt-dev channel, fixed slack icon, move 'req invite' to …

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
           <i class="fab fa-twitter fa-lg"></i>
         </a>
 
-        <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" aria-label="Talk to us in Slack" class="link-social-slack">
+        <a href="https://slack.k8s.io/" data-toggle="tooltip" data-placement="top" title="If you need it, you can request an invite to K8S slack instance." class="link-social-slack">
           <i class="fab fa-slack fa-lg"></i>
         </a>
 
@@ -46,4 +46,3 @@
   </div>
 </div>
 <script src="/js/copy.js"></script>
-

--- a/pages/community.html
+++ b/pages/community.html
@@ -53,51 +53,42 @@ order: 10
       <!-- <iframe src="https://calendar.google.com/calendar/embed?src=18pc0jur01k8f2cccvn5j04j1g%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe> -->
     </div>
   </div>
-  <div class="row align-items-end justify-content-center pt-4 row-community-networks">
+  <div class="row">
     <div class="col-12">
       <h2 class="text-center">Talk to Us!</h2>
       <p class="text-center mt-4">
         We would love to hear from you, how you are using KubeVirt, and what we can do to make it better.
       </p>
-    </div>
-    <div class="col-sm-12 col-md-4 order-md-2 text-center">
-      <a href="https://github.com/{{ site.github_username }}" target="_blank" aria-label="View our repo on GitHub">
-        <img src="{{ site.baseurl }}/assets/images/community-image-col2.svg" class="img-fluid" alt="GitHub icon">
-        <h4 class="pt-3">
-          GitHub Project
-        </h4>
-      </a>
-      <p class="pt-3">
-        Check out the project and consider contributing.
-      </p>
-    </div>
-    <div class="col-sm-12 col-md-4 order-md-3 text-center">
-      <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" target="_blank" aria-label="Chat with us on Slack">
-        <img src="{{ site.baseurl }}/assets/images/community-image-col3.svg" class="img-fluid" alt="Chat image">
-        <h4 class="pt-3">
-          #virtualization
-        </h4>
-      </a>
-      <p class="pt-3">
-        Share your ideas in the #virtualization channel in Kubernetes' Slack.
-      </p>
-      <p class="pt-3">
-        If you need it, you can <a href="https://slack.k8s.io/">request an invite to K8S slack</a> instance.
-      </p>
-    </div>
-    <div class="col-sm-12 col-md-4 order-md-1 text-center">
-      <a href="https://twitter.com/{{ site.twitter_username }}" target="_blank" aria-label="Visit us on Twitter">
-        <img src="{{ site.baseurl }}/assets/images/community-image-col1.svg" class="img-fluid" alt="Twitter icon">
-        <h4 class="pt-3">
-          @kubevirt
-        </h4>
-      </a>
-      <p class="pt-3">
-        Get the latest news and updates.
-      </p>
+      <br><br>
     </div>
   </div>
-  <div class="row align-items-start justify-content-left pb-4 row-community-networks--twitter-feed">
+  <div class="row">
+    <div class="col order-md-1 text-center">
+      <a href="https://twitter.com/{{ site.twitter_username }}" target="_blank" aria-label="Visit us on Twitter">
+        <img src="{{ site.baseurl }}/assets/images/community-image-col1.svg" class="img-fluid" alt="Twitter icon">
+        <h4>@kubevirt</h4>
+      </a>
+      <p>Get the latest news and updates</p>
+    </div>
+    <div class="col order-md-2 text-center">
+      <a href="https://github.com/{{ site.github_username }}" target="_blank" aria-label="View our repo on GitHub">
+        <img src="{{ site.baseurl }}/assets/images/community-image-col2.svg" class="img-fluid" alt="GitHub icon">
+        <h4>GitHub Project</h4>
+      </a>
+      <p>Check out the project and consider contributing</p>
+    </div>
+    <div class="col order-md-3 text-center">
+      <svg width="80" height="80" class="c-nav--footer__svgicon c-slackhash" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M19.712.133a5.381 5.381 0 0 0-5.376 5.387 5.381 5.381 0 0 0 5.376 5.386h5.376V5.52A5.381 5.381 0 0 0 19.712.133m0 14.365H5.376A5.381 5.381 0 0 0 0 19.884a5.381 5.381 0 0 0 5.376 5.387h14.336a5.381 5.381 0 0 0 5.376-5.387 5.381 5.381 0 0 0-5.376-5.386" fill="#36C5F0"></path><path d="M53.76 19.884a5.381 5.381 0 0 0-5.376-5.386 5.381 5.381 0 0 0-5.376 5.386v5.387h5.376a5.381 5.381 0 0 0 5.376-5.387m-14.336 0V5.52A5.381 5.381 0 0 0 34.048.133a5.381 5.381 0 0 0-5.376 5.387v14.364a5.381 5.381 0 0 0 5.376 5.387 5.381 5.381 0 0 0 5.376-5.387" fill="#2EB67D"></path><path d="M34.048 54a5.381 5.381 0 0 0 5.376-5.387 5.381 5.381 0 0 0-5.376-5.386h-5.376v5.386A5.381 5.381 0 0 0 34.048 54m0-14.365h14.336a5.381 5.381 0 0 0 5.376-5.386 5.381 5.381 0 0 0-5.376-5.387H34.048a5.381 5.381 0 0 0-5.376 5.387 5.381 5.381 0 0 0 5.376 5.386" fill="#ECB22E"></path><path d="M0 34.249a5.381 5.381 0 0 0 5.376 5.386 5.381 5.381 0 0 0 5.376-5.386v-5.387H5.376A5.381 5.381 0 0 0 0 34.25m14.336-.001v14.364A5.381 5.381 0 0 0 19.712 54a5.381 5.381 0 0 0 5.376-5.387V34.25a5.381 5.381 0 0 0-5.376-5.387 5.381 5.381 0 0 0-5.376 5.387" fill="#E01E5A"></path></g></svg>
+      <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" target="_blank" aria-label="Chat with us on Slack">
+        <h4>#virtualization<p>Share your experiece</p></h4>
+      </a>
+      <a href="https://kubernetes.slack.com/archives/C0163DT0R8X" target="_blank" aria-label="Chat with us on Slack">
+        <h4>#kubevirt-dev<p>Connect with other developers</p>
+        </h4>
+      </a>
+    </div>
+  </div>
+  <div class="row bg-white align-items-start justify-content-left pb-4 row-community-networks--twitter-feed">
     <div class="col-sm-12 col-md-10 offset-md-1">
       <div class="twitter-arrow_up"></div>
       <div class="twitter-feed">


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new kubevirt-dev channel, fixed slack icon, move 'req invite' to footer icon, cleaned up some layout

To test ...
* Browse to test instance then community page
* drag web browser to smallest possible horizontal setting, scroll up and down.  all bootstrap rows should render correctly.  Twitter feed should populate.
* notice slack icon fixed
* kubevirt-dev channel added
* links for both virtualization & #kubevirt-dev should hyperlink to appropriate slack channels
* Hover over slack icon in footer, tool tip should appear after 2 secs
* Click on slack icon in footer, browser should hyperlink to invite page in slack.

Ref: [KNIECO-2289](https://issues.redhat.com/browse/KNIECO-2289)

