### PR TITLE
Bump memory used in examples to 4096M

### DIFF
--- a/_posts/2018-05-07-Deploying-VMs-on-Kubernetes-GlusterFS-KubeVirt.markdown
+++ b/_posts/2018-05-07-Deploying-VMs-on-Kubernetes-GlusterFS-KubeVirt.markdown
@@ -411,7 +411,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       terminationGracePeriodSeconds: 0
       volumes:
       - cloudInitNoCloud:

--- a/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
+++ b/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
@@ -42,7 +42,7 @@ spec:
         volumeName: registryvolume
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   volumes:
   - name: registryvolume
     registryDisk:

--- a/_posts/2018-11-20-ignition-support.markdown
+++ b/_posts/2018-11-20-ignition-support.markdown
@@ -96,7 +96,7 @@ spec:
               bridge: {}
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       networks:
         - name: default
           pod: {}

--- a/_posts/2019-03-14-More-about-Kubevirt-metrics.markdown
+++ b/_posts/2019-03-14-More-about-Kubevirt-metrics.markdown
@@ -68,7 +68,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       networks:
         - name: default
           pod: {}

--- a/_posts/2019-05-21-kubevirt-with-ansible-part-1.markdown
+++ b/_posts/2019-05-21-kubevirt-with-ansible-part-1.markdown
@@ -65,7 +65,7 @@ kubevirt_vm:
   namespace: default
   name: vm1
   cpu_cores: 1
-  memory: 64Mi
+  memory: 4096M
   disks:
     - name: containerdisk
       volume:

--- a/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
+++ b/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
@@ -120,7 +120,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - name: pvcdisk
@@ -149,7 +149,7 @@ spec:
   domain:
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
     devices:
       disks:
         - name: mypvcdisk
@@ -190,7 +190,7 @@ spec:
               name: datavolumedisk1
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       volumes:
         - dataVolume: #Note the type is dataVolume
             name: alpine-dv

--- a/_posts/releases/2018-07-23-Kubevirt-v0.7.0.markdown
+++ b/_posts/releases/2018-07-23-Kubevirt-v0.7.0.markdown
@@ -31,7 +31,7 @@ spec:
   domain:
     resources:
       requests:
-        memory: "64Mi"
+        memory: 4096M
     memory:
       hugepages:
         pageSize: "2Mi"
@@ -92,7 +92,7 @@ spec:
   domain:
     resources:
       requests:
-        memory: "64Mi"
+        memory: 4096M
     disks:
       - name: myimage
         volumeName: myimage

--- a/labs/manifests/vm.yaml
+++ b/labs/manifests/vm.yaml
@@ -24,7 +24,7 @@ spec:
             bridge: {}
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       networks:
       - name: default
         pod: {}


### PR DESCRIPTION
This number was chosen as the Windows minimum requirement of RAM.

Many users trying out things will copy a valid YAML and change it
to another OS, and 64M (used widely) is too low for many operating
systems. The failures are confusing and hard to understand, and
we can spare them this. Anyone wanting to cut down on usage can
always do so.