### PR TITLE
Fix Liquid syntax errors

### DIFF
--- a/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
+++ b/_posts/2018-10-03-KubeVirt-Network-Rehash.markdown
@@ -121,11 +121,13 @@ All the nodes are virtual instances configured by libvirt.
 
 After creating the service and endpoints objects lets confirm that DNS is resolving correctly.
 
+{% raw %}
 ```
 $ ssh fedora@$(oc get pod -l kubevirt-vm=nodejs --template '{{ range .items }}{{.status.podIP}}{{end}}') \
 "python3 -c \"import socket;print(socket.gethostbyname('mongo.vm.svc.cluster.local'))\""
 192.168.123.139
 ```
+{% endraw %}
 
 ### Node
 
@@ -206,6 +208,7 @@ communication and route to virtual machine.
 We have created two headless services one for node and one for mongo.
 This allows us to use the hostname mongo to connect to MongoDB via the alternative interface.
 
+{% raw %}
 ```
 $ oc get services
 NAME      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)     AGE
@@ -215,6 +218,7 @@ node      ClusterIP   None         <none>        8080/TCP    7h
 $ ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') cat /etc/sysconfig/nodejs
 MONGO_URL=mongodb://nodejs:nodejspassword@mongo.vm.svc.cluster.local/nodejs
 ```
+{% endraw %}
 
 ### endpoints
 
@@ -373,7 +377,9 @@ Fortunately the vm interfaces are fairly typical. Two interfaces: one that has b
 pod ip address and the other the `ovs-cni` layer 2 interface. The `eth1` interface receives a IP address
 from DHCP provided by dnsmasq that was configured by libvirt network on the physical host.
 
+{% raw %}
 `~ ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') sudo ip a`
+{% endraw %}
 
 ```
 ...output...
@@ -397,7 +403,9 @@ In this example we want to use Kubernetes services so special care must be used 
 configuring the network interfaces. The default route and dns configuration must be
 maintained by `eth0`. `eth1` has both route and dns configuration disabled.
 
+{% raw %}
 `~ ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') sudo cat /etc/sysconfig/network-scripts/ifcfg-eth0`
+{% endraw %}
 
 ```
 BOOTPROTO=dhcp
@@ -410,7 +418,9 @@ DEFROUTE=yes
 PEERDNS=yes
 ```
 
+{% raw %}
 `~ ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') sudo cat /etc/sysconfig/network-scripts/ifcfg-eth1`
+{% endraw %}
 
 ```
 BOOTPROTO=dhcp
@@ -426,7 +436,9 @@ DEFROUTE=no
 
 Just quickly wanted to cat the `/etc/resolv.conf` file to show that DNS is configured so that kube-dns will be properly queried.
 
+{% raw %}
 `~ ssh fedora@$(oc get pod virt-launcher-nodejs-76xk7 --template '{{.status.podIP}}') sudo cat /etc/resolv.conf`
+{% endraw %}
 
 ```
 search vm.svc.cluster.local. svc.cluster.local. cluster.local. 168.122.112.nip.io.
@@ -459,7 +471,9 @@ connection to MongoDB and finally check the NodeJS logs looking for confirmation
 After connecting to the nodejs virtual machine via ssh we can use `ss` to determine the current TCP connections.
 We are specifically looking for the established connections to the MongoDB service that is running on the mongodb virtual machine.
 
+{% raw %}
 `ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') sudo ss -tanp`
+{% endraw %}
 
 ```
 State      Recv-Q Send-Q Local Address:Port               Peer Address:Port
@@ -474,7 +488,9 @@ ESTAB      0      0      192.168.123.140:33164              192.168.123.139:2701
 
 Here we are reviewing the logs of node to confirm we have a database connection to mongo via the service hostname.
 
+{% raw %}
 `ssh fedora@$(oc get pod virt-launcher-nodejs-dlgv6 --template '{{.status.podIP}}') sudo journalctl -u nodejs`
+{% endraw %}
 
 ```
 ...output...

--- a/pages/blogs/date.md
+++ b/pages/blogs/date.md
@@ -16,51 +16,51 @@ order: 10
     </div>
     <div class="col-sm-12 col-md-9 blogs">
 
-{%comment%} ++++++++++ We first find start and end years ++++++++++ {%endcomment%}
+{% comment %} ++++++++++ We first find start and end years ++++++++++ {% endcomment %}
 {% assign startYear = 2222 %}
 {% assign endYear   = 1 %}
 
 {% for post in site.posts %}
-{%comment%} +++++
+{% comment %} +++++
 "| plus: 0" casts postYear to fixnum, because "post.date | date: "%Y"" is a string
 and comparing "2013" with 2012 (string / number) throws an error
-+++++ {%endcomment%}
++++++ {% endcomment %}
 {% assign postYear = post.date | date: "%Y" | plus: 0 %}
 
 {% if postYear > endYear %}{% assign endYear = postYear %}{% endif %}
 {% if postYear < startYear %}{% assign startYear = postYear %}{% endif %}
 {% endfor %}
 
-{%comment%} +++++++++++++++ build the table +++++++++++++++ {%endcomment%}
+{% comment %} +++++++++++++++ build the table +++++++++++++++ {% endcomment %}
 
 {% assign tableContent = "<tr><th></th><th>Jan</th><th>Feb</th><th>Mar</th><th>Apr</th><th>May</th><th>Jun</th><th>Jul</th><th>Aug</th><th>Sep</th><th>Oct</th><th>Nov</th><th>Dec</th></tr>" %}
 
-{%comment%} +++++
+{% comment %} +++++
 currentPostIndex is used to loop over post in an efficient way
 Knowing that posts a sorted by date, we don't need to loop over
 all posts each time we want to inspect them.
 Instead we only loop through posts we don't already inspect.
-+++++ {%endcomment%}
++++++ {% endcomment %}
 {% assign currentPostIndex = 0 %}
 
-{%comment%} +++++ site.posts array is zero numbered, so last index = size-1 +++++ {%endcomment%}
+{% comment %} +++++ site.posts array is zero numbered, so last index = size-1 +++++ {% endcomment %}
 {% assign lastPostIndex = site.posts.size | minus: 1 %}
 
-{%comment%} +++++ Looping trough years in REVERSE order +++++ {%endcomment%}
-{% for year in (startYear...endYear) reversed %}
+{% comment %} +++++ Looping trough years in REVERSE order +++++ {% endcomment %}
+{% for year in (startYear..endYear) reversed %}
 
 {% assign yearRow = "<tr><th>" | append: year | append: "</th>" %}
 
-{%comment%} +++++ Trick to create an empty array +++++ {%endcomment%}
+{% comment %} +++++ Trick to create an empty array +++++ {% endcomment %}
 {% assign yearCellsArray = "" | split: "/" %}
 
-{%comment%} +++++ Looping over month reversed +++++ {%endcomment%}
-{% for month in (1...12) reversed %}
+{% comment %} +++++ Looping over month reversed +++++ {% endcomment %}
+{% for month in (1..12) reversed %}
 
     {% assign postsThisYearMonth = 0 %}
     {% assign monthCell = "<td>" %}
 
-    {% for postIndex in (currentPostIndex...lastPostIndex) %}
+    {% for postIndex in (currentPostIndex..lastPostIndex) %}
 
       {% assign p      = site.posts[postIndex] %}
       {% assign pYear  = p.date | date: "%Y" | plus: 0 %}
@@ -69,7 +69,7 @@ Instead we only loop through posts we don't already inspect.
       {% if pYear == year and pMonth == month %}
         {% assign postsThisYearMonth = postsThisYearMonth | plus: 1 %}
       {% else %}
-        {%comment%} +++++ Here we stop the loop +++++ {%endcomment%}
+        {% comment %} +++++ Here we stop the loop +++++ {% endcomment %}
         {% assign currentPostIndex = postIndex %}
         {% break %}
       {% endif %}
@@ -103,21 +103,21 @@ Instead we only loop through posts we don't already inspect.
   </tbody>
 </table>
 
-{%comment%} +++++ Printing posts by Year then month +++++ {%endcomment%}
+{% comment %} +++++ Printing posts by Year then month +++++ {% endcomment %}
 
 {% assign currentPostIndex = 0 %}
 {% assign lastPostIndex = site.posts.size | minus: 1 %}
 
-{% for year in (startYear...endYear) reversed %}
+{% for year in (startYear..endYear) reversed %}
 
   <h2>{{year}}</h2>
   {% assign currentYear = year %}
-  {% for month in (1...12) reversed %}
+  {% for month in (1..12) reversed %}
 
     {% assign postsArray = "" | split: "/" %}
 
-    {%comment%} +++++ Find post for this year / month +++++ {%endcomment%}
-    {% for postIndex in (currentPostIndex...lastPostIndex) %}
+    {% comment %} +++++ Find post for this year / month +++++ {% endcomment %}
+    {% for postIndex in (currentPostIndex..lastPostIndex) %}
       {% assign p      = site.posts[postIndex] %}
       {% assign pYear  = p.date | date: "%Y" | plus: 0 %}
       {% assign pMonth = p.date | date: "%m" | plus: 0 %}
@@ -125,7 +125,7 @@ Instead we only loop through posts we don't already inspect.
       {% if pYear == year and pMonth == month %}
         {% assign postsArray = postsArray | push: p %}
       {% else %}
-        {%comment%} +++++ Here we stop the loop +++++ {%endcomment%}
+        {% comment %} +++++ Here we stop the loop +++++ {% endcomment %}
         {% assign currentPostIndex = postIndex %}
         {% break %}
       {% endif %}
@@ -133,10 +133,10 @@ Instead we only loop through posts we don't already inspect.
 
     {% assign postArraySize = postsArray | size %}
 
-    {%comment%} +++++ Printing posts if we have some for this year month +++++ {%endcomment%}
+    {% comment %} +++++ Printing posts if we have some for this year month +++++ {% endcomment %}
     {% if postArraySize and postArraySize > 0 %}
 
-      {%comment%} +++++ get month name from a post.date +++++ {%endcomment%}
+      {% comment %} +++++ get month name from a post.date +++++ {% endcomment %}
       {% assign post = postsArray | first %}
       {% assign monthName = post.date | date: "%B" %}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Liquid syntax errors around page building, due to Jekyll trying to render/read code blocks that are not used in the creation of the site. Use the `{% raw %} and {% endraw %}` escapes to force Jekyll to ignore the code block.

For future pages with this issue, the `{% raw %} and {% endraw %}` must be placed around any `{% for %}` and `{% endfor %}` expressions, or else they will fail with the error _Unknown tag 'endfor'_.

**Does this PR fix any issue?** 
> Fixes #598

**Special notes for your reviewer**:
Run `Jekyll Build` to see that the `Liquid Warning: Liquid syntax error...` errors are no longer present.