### PR TITLE
Use a newer Ruby version in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache:
   bundler: true
 rvm:
-- 2.3.3
+- 2.5.3
 before_install:
 - bundle install
 - npm install -g yaspeller


### PR DESCRIPTION
**What this PR does / why we need it**:
Use a newer Ruby version in travis-ci