### PR TITLE
Update to Vagrant Getting-started guide url to fix HTMLproofer failures.

### DIFF
--- a/_posts/2019-06-04-Kubevirt-vagrant-provider.markdown
+++ b/_posts/2019-06-04-Kubevirt-vagrant-provider.markdown
@@ -25,7 +25,7 @@ The KubeVirt Vagrant provider implements the following features:
 
 # Installation
 
-In order to use the provider we need to install Vagrant first. The steps how to do it are available [here](https://www.vagrantup.com/intro/getting-started/install.html). Once command line tool is available in our system, we can install the plugin by running:
+In order to use the provider we need to install Vagrant first. The steps how to do it are available [here](https://learn.hashicorp.com/collections/vagrant/getting-started). Once command line tool is available in our system, we can install the plugin by running:
 
 ```
 $ vagrant plugin install vagrant-kubevirt


### PR DESCRIPTION
**What this PR does / why we need it**:
HTMLproofer running in Netlify is failing because this url is now a redirect.  HTMLproofer runs successfully both locally on the metal and within the container.  Hopefully this fixes the problem so pull/614 can proceed.