### PR TITLE
Update to fix links and containerdisk

### DIFF
--- a/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
+++ b/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
@@ -38,15 +38,15 @@ spec:
       disks:
       - disk:
           bus: virtio
-        name: registrydisk
-        volumeName: registryvolume
+        name: containerdisk
+        volumeName: containerdisk
     resources:
       requests:
         memory: 64M
   volumes:
-  - name: registryvolume
-    registryDisk:
-      image: kubevirt/cirros-registry-disk-demo:devel
+  - name: containerdisk
+    containerDisk:
+      image: kubevirt/cirros-container-disk-demo:devel
 ```
 
 In the spec above, we see the KubeVirt VirtualMachine object has an _apiVersion_
@@ -178,4 +178,4 @@ these roles will prevent admins from ever having to create their own custom
 KubeVirt RBAC roles.
 
 More information about these default roles can be found in the KubeVirt
-user guide [here](https://kubevirt.io/user-guide/#/authorization)
+user guide [here](https://kubevirt.io/user-guide/#/installation/authorization)

--- a/_posts/2018-11-16-new-volume-types.markdown
+++ b/_posts/2018-11-16-new-volume-types.markdown
@@ -58,8 +58,8 @@ spec:
   domain:
     devices:
       disks:
-        - name: registrydisk
-          volumeName: registryvolume
+        - name: containerdisk
+          volumeName: containervolume
         - name: cloudinitdisk
           volumeName: cloudinitvolume
         - name: configmap-disk
@@ -75,9 +75,9 @@ spec:
       requests:
         memory: 1024M
   volumes:
-    - name: registryvolume
-      registryDisk:
-        image: kubevirt/fedora-cloud-registry-disk-demo:latest
+    - name: containervolume
+      containerDisk:
+        image: kubevirt/fedora-cloud-container-disk-demo:latest
     - name: cloudinitvolume
       cloudInitNoCloud:
         userData: |-
@@ -146,4 +146,4 @@ default
 ## Summary
 
 With these new volume types KubeVirt further improves the integration with native Kubernetes resources.
-Learn more about all available volume types on the [userguide](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes).
+Learn more about all available volume types on the [userguide](https://kubevirt.io/user-guide/#/creation/disks-and-volumes).

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -22,7 +22,7 @@ You can experiment this lab online at [![Katacoda](/assets/images/katacoda-logo.
 
 ### Create a Virtual Machine
 
-Download the VM manifest and explore it. Note it uses a [registry disk](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes?id=registrydisk) and as such doesn't persist data. Such registry disks currently exist for alpine, cirros and fedora.
+Download the VM manifest and explore it. Note it uses a [containerDisk](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=containerdisk) and as such doesn't persist data. Images currently exist for alpine, cirros and fedora.
 
 ```bash
 {% include scriptlets/lab1/01_get_vm_manifest.sh -%}


### PR DESCRIPTION
**What this PR does / why we need it**:
This should fix...
1) Pages with links to user-guide throwing 404 - Not Found pages
2) These pages also reference registryDisk which was migrated to containerDisk