### PR TITLE
Adds controller-lifecycle-operator-sdk meta tag to support vanity import

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -318,6 +318,7 @@
     "SCC",
     "schedulable",
     "scu",
+    "sdk",
     "SDN",
     "securityContext",
     "selinux",

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
     <meta name="go-import" content="kubevirt.io/qe-tools git https://github.com/kubevirt/qe-tools">
     <meta name="go-import" content="kubevirt.io/machine-remediation git https://github.com/kubevirt/machine-remediation">
     <meta name="go-import" content="kubevirt.io/cloud-provider-kubevirt git https://github.com/kubevirt/cloud-provider-kubevirt">
+    <meta name="go-import" content="kubevirt.io/controller-lifecycle-operator-sdk git https://github.com/kubevirt/controller-lifecycle-operator-sdk">
     <link rel="apple-touch-icon" sizes="72x72" href="{{ site.baseurl }}/assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/assets/favicon/favicon-16x16.png">

--- a/pages/controller-lifecycle-operator-sdk.md
+++ b/pages/controller-lifecycle-operator-sdk.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title:
+permalink: /controller-lifecycle-operator-sdk/
+---
+
+To fetch Controller Lifecycle Operator SDK sources run `go get -d kubevirt.io/controller-lifecycle-operator-sdk`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds go import redirect for controller-lifecycle-operator-sdk module.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>