### PR TITLE
Fix redirection links in cloud quickstart pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We more than welcome contributions in the form of blog posts, pages and/or labs,
 ### Verify internal and external hyperlinks
 
   ```console
-  podman run -it --rm --name link-check -p 4000:4000 -v $(pwd):/srv/jekyll:Z jekyll/jekyll /bin/bash -c "bundle install; rake"
+  podman run -it --rm --name link-check -p 4000:4000 -v $(pwd):/srv/jekyll:Z jekyll/jekyll /bin/bash -c "bundle install && bundle exec rake -- -u"
   ```
 
 ### View the site

--- a/pages/alicloud.md
+++ b/pages/alicloud.md
@@ -5,5 +5,5 @@ permalink: pages/alicloud
 lab: kubernetes
 order: 1
 redirect_to:
-  - /pages/cloud
+  - /quickstart_cloud/
 ---

--- a/pages/cloud.md
+++ b/pages/cloud.md
@@ -1,7 +1,7 @@
 ---
 layout: labs
-title: Easy install using Azure
-permalink: pages/azure
+title: Easy install on cloud providers
+permalink: pages/cloud
 lab: kubernetes
 order: 1
 redirect_to:

--- a/pages/ec2.md
+++ b/pages/ec2.md
@@ -5,5 +5,5 @@ permalink: pages/ec2
 lab: kubernetes
 order: 1
 redirect_to:
-  - /pages/cloud
+  - /quickstart_cloud/
 ---

--- a/pages/gcp.md
+++ b/pages/gcp.md
@@ -5,5 +5,5 @@ permalink: pages/gcp
 lab: kubernetes
 order: 1
 redirect_to:
-  - /pages/cloud
+  - /quickstart_cloud/
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The recent change in #612 moved the /try it on clouds/ page from `cloud` to `quickstart_cloud`. There were some pages linking to `cloud`. This PR updates redirects so that they point to `quickstart_cloud` instead, and adds a redirect from `cloud` to `quickstart_cloud` for any potential external links pointing there.

Also it updates the `README` instructions about link checking to match what's defined in the prow job for link checks.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
