### PR TITLE
Update our documentation to point to the container disk images we currently support

### DIFF
--- a/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
+++ b/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
@@ -46,7 +46,7 @@ spec:
   volumes:
   - name: registryvolume
     registryDisk:
-      image: kubevirt/cirros-registry-disk-demo:devel
+      image: kubevirt/cirros-container-disk-demo:devel
 ```
 
 In the spec above, we see the KubeVirt VirtualMachine object has an _apiVersion_

--- a/_posts/2018-06-21-Run-Istio-with-kubevirt.markdown
+++ b/_posts/2018-06-21-Run-Istio-with-kubevirt.markdown
@@ -215,7 +215,7 @@ spec:
   volumes:
     - name: registryvolume
       registryDisk:
-        image: kubevirt/fedora-cloud-registry-disk-demo:latest
+        image: kubevirt/fedora-cloud-container-disk-demo:latest
     - cloudInitNoCloud:
         userData: |-
           #!/bin/bash

--- a/_posts/2018-09-11-KubeVirt-Memory-Overcommit.markdown
+++ b/_posts/2018-09-11-KubeVirt-Memory-Overcommit.markdown
@@ -58,7 +58,7 @@ spec:
   volumes:
     - name: myvolume
       registryDisk:
-        image: <registry_address>/kubevirt/fedora-cloud-registry-disk-demo:latest
+        image: <registry_address>/kubevirt/fedora-cloud-container-disk-demo:latest
     - cloudInitNoCloud:
       userData: |
         #cloud-config
@@ -105,7 +105,7 @@ spec:
   volumes:
     - name: myvolume
       registryDisk:
-        image: <registry_url>/kubevirt/fedora-cloud-registry-disk-demo:latest
+        image: <registry_url>/kubevirt/fedora-cloud-container-disk-demo:latest
     - cloudInitNoCloud:
         userData: |
           #cloud-config

--- a/_posts/2018-09-12-attaching-to-multiple-networks.markdown
+++ b/_posts/2018-09-12-attaching-to-multiple-networks.markdown
@@ -263,7 +263,7 @@ spec:
   volumes:
     - name: registryvolume
       registryDisk:
-        image: kubevirt/fedora-cloud-registry-disk-demo
+        image: kubevirt/fedora-cloud-container-disk-demo
     - cloudInitNoCloud:
         userData: |
           #!/bin/bash

--- a/_posts/2018-11-16-new-volume-types.markdown
+++ b/_posts/2018-11-16-new-volume-types.markdown
@@ -77,7 +77,7 @@ spec:
   volumes:
     - name: registryvolume
       registryDisk:
-        image: kubevirt/fedora-cloud-registry-disk-demo:latest
+        image: kubevirt/fedora-cloud-container-disk-demo:latest
     - name: cloudinitvolume
       cloudInitNoCloud:
         userData: |-

--- a/_posts/2019-06-04-Kubevirt-vagrant-provider.markdown
+++ b/_posts/2019-06-04-Kubevirt-vagrant-provider.markdown
@@ -97,7 +97,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :kubevirt do |kubevirt|
     kubevirt.cpus = 2
     kubevirt.memory = 512
-    kubevirt.image = 'kubevirt/fedora-cloud-registry-disk-demo'
+    kubevirt.image = 'kubevirt/fedora-cloud-container-disk-demo'
   end
 
   # defines a user configured on a virtual machine using cloud-init

--- a/assets/2019-02-22-federated-kubevirt/federated_vm.yaml
+++ b/assets/2019-02-22-federated-kubevirt/federated_vm.yaml
@@ -35,7 +35,7 @@ spec:
             pod: {}
           volumes:
           - containerDisk:
-              image: kubevirt/cirros-registry-disk-demo:latest
+              image: kubevirt/cirros-container-disk-demo:latest
             name: containerdisk
           - name: pvcdisk
             persistentVolumeClaim:

--- a/labs/manifests/vm.yaml
+++ b/labs/manifests/vm.yaml
@@ -31,7 +31,7 @@ spec:
       volumes:
         - name: containerdisk
           containerDisk:
-            image: kubevirt/cirros-registry-disk-demo
+            image: kubevirt/cirros-container-disk-demo
         - name: cloudinitdisk
           cloudInitNoCloud:
             userDataBase64: SGkuXG4=


### PR DESCRIPTION
Our  documentation is pointing to containerDisk images that are no longer maintained. A year or so ago we changed the name of the containerDisk feature from registryDisk to containerDisk. With that change, our demo image names changed from *-registry-disk-demo to *-container-disk-demo. 