### PR TITLE
Make the popup video auto-play when open

### DIFF
--- a/js/video.popup.js
+++ b/js/video.popup.js
@@ -9,7 +9,7 @@
         }
 
         var settings = $.extend({
-            autoplay: false,
+            autoplay: true,
             showControls: true,
             controlsColor: null,
             loopVideo: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

This change makes the "KubeVirt overview" video in the home page start to play as soon as it pops up.

Currently to view the video you need 2 clicks. With that, it's just 1 click.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
