### PR TITLE
Add custom user agent to HTMLProofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,11 +17,9 @@ namespace :links do
             :log_level          => :info,
             :internal_domains   => ["https://instructor.labs.sysdeseng.com", "https://www.youtube.com"],
             :external_only      => true,
+            :url_ignore         => [ /http(s)?:\/\/(www.)?katacoda.com.*/ ],
             :url_swap           => {'https://kubevirt.io/' => '',},
             :http_status_ignore => [429],
-            :typhoeus           => {
-              :headers => { "User-Agent" => "Mozilla/5.0 (compatible; HTMLProofer)" }
-            }
         }
 
         parser = OptionParser.new

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,9 @@ namespace :links do
             :external_only      => true,
             :url_swap           => {'https://kubevirt.io/' => '',},
             :http_status_ignore => [429],
+            :typhoeus           => {
+              :headers => { "User-Agent" => "Mozilla/5.0 (compatible; HTMLProofer)" }
+            }
         }
 
         parser = OptionParser.new


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Link checking on Katacoda is [failing with 403 Forbidden](https://travis-ci.org/github/kubevirt/kubevirt.github.io/builds/747946963#L425).

Testing with curl suggests that a custom user agent prevents this:

```
$ curl -I https://www.katacoda.com/kubevirt/scenarios/kubevirt-101
HTTP/1.1 403 Forbidden
Date: Mon, 07 Dec 2020 09:30:30 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
Set-Cookie: __cfduid=de2cf3a12516943dfd2830c767705da391607333430; expires=Wed, 06-Jan-21 09:30:30 GMT; path=/; domain=.katacoda.com; HttpOnly; SameSite=Lax
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
X-Katacoda-Host: web
X-Katacoda-Region: europe
Set-Cookie: connect.sid=s%3AnuVNIfMzW1TxqYEosizpCmUOJOn6pyZJ.K8sIm9GxB8nNzwRgPpnVvqt9j68eSrMcjbdYWNhcDrg; Domain=.katacoda.com; Path=/; Expires=Tue, 01 Jun 2021 12:13:28 GMT; HttpOnly; Secure; SameSite=None
Via: 1.1 google
Set-Cookie: GCLB=CIrH4-7XhrKGCA; path=/; HttpOnly
CF-Cache-Status: DYNAMIC
cf-request-id: 06de22dd240000067eee33e000000001
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=cEtVKKHGXTn5LV%2BkOxH0I2Fki0B%2FDoyLfT%2F9opOBQf%2BTk2p%2BBGbR%2B2RoICHjhrAkNarhd8jSf6t0a4xhRLvIBK7Z%2FCSKw%2BOtkZDDmaJNygn2"}],"group":"cf-nel","max_age":604800}
NEL: {"report_to":"cf-nel","max_age":604800}
Server: cloudflare
CF-RAY: 5fdd3a750a51067e-LHR

$ curl -I -A 'Mozilla/5.0 (compatible; HTMLProofer)' https://www.katacoda.com/kubevirt/scenarios/kubevirt-101
HTTP/1.1 200 OK
Date: Mon, 07 Dec 2020 09:30:12 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
Set-Cookie: __cfduid=d7ff618883f82fa6a1ddccb9bd675f94e1607333412; expires=Wed, 06-Jan-21 09:30:12 GMT; path=/; domain=.katacoda.com; HttpOnly; SameSite=Lax
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
X-Katacoda-Host: web
X-Katacoda-Region: europe
Set-Cookie: temp-user-id=11327820; Max-Age=900; Domain=.katacoda.com; Path=/; Expires=Mon, 07 Dec 2020 09:45:12 GMT; Secure; SameSite=None
Set-Cookie: course-session-id=17793081; Max-Age=0; Domain=.katacoda.com; Path=/; Expires=Mon, 07 Dec 2020 09:30:12 GMT; Secure; SameSite=None
Set-Cookie: connect.sid=s%3AEBAnp0SG2gzCFFkqh4od3pKFbcA4vzUw.cjFHZXTmabROI9o8MDDiWmVpFlMzK5EfLtq%2BM%2F4UEnM; Domain=.katacoda.com; Path=/; Expires=Tue, 01 Jun 2021 12:13:28 GMT; HttpOnly; Secure; SameSite=None
Via: 1.1 google
Set-Cookie: GCLB=CN3uo-ONs5CLQg; path=/; HttpOnly
CF-Cache-Status: DYNAMIC
cf-request-id: 06de2294a70000007910051000000001
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Report-To: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=KQj4kGc1WxQleBCJ8ZwaU91X4AtOygT%2FPd4lk%2FqgtUKVb0g0IUqykkXWLws0snwthj9YVA%2BJajF6ByRe97t3%2F908%2Fj3ADS2TzUmCpkORMI7l"}],"group":"cf-nel","max_age":604800}
NEL: {"report_to":"cf-nel","max_age":604800}
Server: cloudflare
CF-RAY: 5fdd3a010b470079-LHR
```


**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
