### PR TITLE
Remove the CfP from the summit page

### DIFF
--- a/pages/summit.md
+++ b/pages/summit.md
@@ -22,29 +22,12 @@ The event will take place online during two half-days:
   - Dates: **February 9 and 10**, 2021.
   - Time: 15:00 – 19:00 UTC (10:00–14:00 EST, 16:00–20:00 CET)
 
-## Call for Proposals
-
-We want to encourage anyone who is interested in presenting or discussing a
-topic to submit a session proposal.
-
-There are two main content tracks, users and contributors, to differentiate the expected audience for each session.
-
-Submit a topic by creating a Pull Request to
-our community repo
-[proposals directory](https://github.com/kubevirt/community/tree/master/events/2021-kubevirt-summit/proposals):
-
-  1. Copy the
-     [template](https://github.com/kubevirt/community/blob/master/events/2021-kubevirt-summit/proposals/proposal-template.md)
-     in that repo directory as a new file.
-  2. Edit your proposal and fill in the details pertaining to your session.
-  3. Submit your proposal as a Pull Request.
-
-The deadline for proposals to be accepted is Friday January 22nd.
-
 ## Logistics
 
 This page will be updated as more details become available (registrations,
 online platform access details, conference detailed schedule).
+
+We are currently working to have a public schedule by the end of January.
 
 ## Sponsors
 


### PR DESCRIPTION

**What this PR does / why we need it**:

This removes the part of the landing page with instructions about the process to submit a proposal.

The summit was accepting proposals until end of last week, so these are obsolete now.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
