### PR TITLE
Update the summit event link to the info page

### DIFF
--- a/pages/summit.md
+++ b/pages/summit.md
@@ -27,9 +27,11 @@ accommodate more content proposals in the schedule.
 
 ## Registration
 
-Registrations are **now open** for the event! There is no cost for registration.
+Registrations are **now open** for the event!
 
-Register now [here](https://community.cncf.io/j/2heck9gd9ykxs/).
+**Register now [here](https://community.cncf.io/e/mj79ss/)**.
+
+There is no cost for registration. A Linux Foundation account is required.
 
 ## Program
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The URL used for the registration takes you straight to register; the first thing you see when clicking that link is a Linux Foundation login page (unless you were already logged in to the LF).

This changes the URL to the more friendly event page, which provides some information.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
