### PR TITLE
Fix user guide links

### DIFF
--- a/_posts/2018-04-25-KubeVirt-Network-Deep-Dive.markdown
+++ b/_posts/2018-04-25-KubeVirt-Network-Deep-Dive.markdown
@@ -145,7 +145,7 @@ Once all the nodes have been joined check the status.
 
 The recommended installation method is to use [kubevirt-ansible](https://github.com/kubevirt/kubevirt-ansible). For this example I don’t require storage so just deploying using `kubectl create`.
 
-For additional information regarding KubeVirt install see the [installation readme](http://kubevirt.io/user-guide/#/installation/installation).
+For additional information regarding KubeVirt install see the [installation readme](https://kubevirt.io/user-guide/operations/installation/).
 
     $ kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/v0.4.1/kubevirt.yaml
     serviceaccount "kubevirt-apiserver" created

--- a/_posts/2018-05-08-KubeVirt-objects.markdown
+++ b/_posts/2018-05-08-KubeVirt-objects.markdown
@@ -34,7 +34,7 @@ Below is a list of the top level API objects and descriptions that KubeVirt prov
 
 - VirtualMachineReplicaSet (vmrs\[s\]) - tries to ensures that a specified number of VirtualMachine replicas are running at any time.
 
-[DomainSpec](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_domainspec) is listed as a top-level object but is only used within all of the objects above. Currently the `DomainSpec` is a subset of what is configurable via [libvirt domain XML](https://libvirt.org/formatdomain.html).
+[DomainSpec](http://kubevirt.io/api-reference/master/definitions.html#_v1_domainspec) is listed as a top-level object but is only used within all of the objects above. Currently the `DomainSpec` is a subset of what is configurable via [libvirt domain XML](https://libvirt.org/formatdomain.html).
 
 ## VirtualMachine
 
@@ -95,7 +95,7 @@ spec: {}
 
 Kubernetes has the ability to schedule a pod to specific nodes based on [affinity and anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature) rules.
 
-[Node affinity](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_nodeaffinity) is also possible with KubeVirt. To [constrain a virtual machine](https://kubevirt.io/user-guide/#/usage/node-placement?id=affinity-and-anti-affinity) to run on a node define a matching expressions using node labels.
+[Node affinity](http://kubevirt.io/api-reference/master/definitions.html#_v1_nodeaffinity) is also possible with KubeVirt. To [constrain a virtual machine](hhttps://kubevirt.io/user-guide/operations/node_assignment/#affinity-and-anti-affinity) to run on a node define a matching expressions using node labels.
 
 ```yaml
 affinity:
@@ -117,7 +117,7 @@ affinity:
                 - string
 ```
 
-A virtual machine can also more easily be constrained by using [nodeSelector](https://kubevirt.io/user-guide/#/usage/node-placement?id=nodeselector) which is defined by node’s label and value. Here is an example
+A virtual machine can also more easily be constrained by using [nodeSelector](https://kubevirt.io/user-guide/operations/node_assignment/#nodeselector) which is defined by node’s label and value. Here is an example
 
 ```yaml
 nodeSelector:
@@ -126,7 +126,7 @@ nodeSelector:
 
 ### Clocks and Timers
 
-Configures the [virtualize hardware](https://kubevirt.io/user-guide/#/creation/devices?id=clock) clock provided by [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-9).
+Configures the [virtualize hardware](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#clock) clock provided by [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-9).
 
 ```yaml
 domain:
@@ -136,7 +136,7 @@ domain:
       offsetSeconds: 0
 ```
 
-The [timer](http://kubevirt.io/user-guide/#/workloads/virtual-machines/virtualized-hardware-configuration?id=timers) defines the [type and policy attribute](https://libvirt.org/formatdomain.html#elementsTime) that determines what action is take when QEMU misses a deadline for injecting a tick to the guest.
+The [timer](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#timers) defines the [type and policy attribute](https://libvirt.org/formatdomain.html#elementsTime) that determines what action is take when QEMU misses a deadline for injecting a tick to the guest.
 
 ```yaml
 domain:
@@ -160,14 +160,14 @@ domain:
 
 ### CPU and Memory
 
-The number of [CPU cores](http://kubevirt.io/user-guide/#/workloads/virtual-machines/virtualized-hardware-configuration?id=cpu) a virtual machine will be assigned. [.spec.domain.cpu.cores](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_cpu) will not be used for scheduling use [.spec.domain.resources.requests.cpu](http://kubevirt.io/api-reference/v0.4.1/definitions.html#_v1_resourcerequirements) instead.
+The number of [CPU cores](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#cpu) a virtual machine will be assigned. [.spec.domain.cpu.cores](http://kubevirt.io/api-reference/master/definitions.html#_v1_cpu) will not be used for scheduling use [.spec.domain.resources.requests.cpu](http://kubevirt.io/api-reference/master/definitions.html#_v1_resourcerequirements) instead.
 
 ```yaml
 cpu:
   cores: 1
 ```
 
-There are two supported [resource limits and requests](http://kubevirt.io/user-guide/#/workloads/virtual-machines/virtualized-hardware-configuration?id=resources-requests-and-limits): `cpu` and `memory`. A `.spec.domain.resources.requests.memory` should be defined to determine the allocation of memory provided to the virtual machine. These values will be used to in scheduling decisions.
+There are two supported [resource limits and requests](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#resources-requests-and-limits): `cpu` and `memory`. A `.spec.domain.resources.requests.memory` should be defined to determine the allocation of memory provided to the virtual machine. These values will be used to in scheduling decisions.
 
 ```yaml
 resources:
@@ -177,7 +177,7 @@ resources:
 
 ### Watchdog Devices
 
-[.spec.domain.watchdog](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_watchdog) automatically triggers an action via [Libvirt](https://libvirt.org/formatdomain.html#elementsWatchdog) and [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-9) when the virtual machine operating system hangs or crashes.
+[.spec.domain.watchdog](http://kubevirt.io/api-reference/master/definitions.html#_v1_watchdog) automatically triggers an action via [Libvirt](https://libvirt.org/formatdomain.html#elementsWatchdog) and [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-9) when the virtual machine operating system hangs or crashes.
 
 ```yaml
 watchdog:
@@ -188,14 +188,14 @@ watchdog:
 
 ### Features
 
-[.spec.domain.features](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_features)
+[.spec.domain.features](http://kubevirt.io/api-reference/master/definitions.html#_v1_features)
 are hypervisor cpu or machine features that can be enabled.
 After reviewing both Linux and Microsoft QEMU virtual machines managed by
 [Libvirt](https://libvirt.org/formatdomain.html#elementsFeatures)
 both acpi and
-[apic](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_featureapic)
+[apic](http://kubevirt.io/api-reference/master/definitions.html#_v1_featureapic)
 should be enabled.
-The [hyperv](http://kubevirt.io/api-reference/v0.4.1/definitions.html#_v1_featurehyperv) features should be enabled only for Windows-based virtual machines. For additional information regarding features please visit the [virtual hardware configuration](http://kubevirt.io/user-guide/#/workloads/virtual-machines/virtualized-hardware-configuration?id=features) in the kubevirt user guide.
+The [hyperv](http://kubevirt.io/api-reference/master/definitions.html#_v1_featurehyperv) features should be enabled only for Windows-based virtual machines. For additional information regarding features please visit the [virtual hardware configuration](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#features) in the kubevirt user guide.
 
 ```yaml
 features:
@@ -229,7 +229,7 @@ features:
 
 ### QEMU Machine Type
 
-[.spec.domain.machine.type](https://kubevirt.io/user-guide/#/creation/devices?id=machine-type) is the emulated machine architecture provided by [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-0).
+[.spec.domain.machine.type](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#machine-type) is the emulated machine architecture provided by [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-0).
 
 ```yaml
 machine:
@@ -251,7 +251,7 @@ Here is an example how to retrieve the supported QEMU machine types.
 
 ### Disks and Volumes
 
-[.spec.domain.devices.disks](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_disk) configures a [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-1) type of [disk](https://libvirt.org/formatdomain.html#elementsDisks) to the virtual machine and assigns a specific [volume and its type to that disk](https://kubevirt.io/user-guide/#/creation/disks-and-volumes) via the `volumeName`.
+[.spec.domain.devices.disks](https://kubevirt.io/api-reference/master/definitions.html#_v1_disk) configures a [QEMU](https://www.qemu.org/docs/master/system/invocation.html#hxtool-1) type of [disk](https://libvirt.org/formatdomain.html#elementsDisks) to the virtual machine and assigns a specific [volume and its type to that disk](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) via the `volumeName`.
 
 ```yaml
 devices:
@@ -273,12 +273,12 @@ devices:
       volumeName: string
 ```
 
-[cloudInitNoCloud](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_cloudinitnocloudsource)
+[cloudInitNoCloud](http://kubevirt.io/api-reference/master/definitions.html#_v1_cloudinitnocloudsource)
 injects scripts and configuration into a virtual machine operating system.
 There are three different parameters that can be used to provide the
 cloud-init coniguration: `secretRef`, `userData` or `userDataBase64`.
 
-See the user-guide for examples of how to use [.spec.volumes.cloudInitNoCloud](https://kubevirt.io/user-guide/#/creation/cloud-init?id=cloud-init-examples).
+See the user-guide for examples of how to use [.spec.volumes.cloudInitNoCloud](https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#cloud-init-examples).
 
 ```yaml
 volumes:
@@ -289,14 +289,14 @@ volumes:
       userDataBase64: string
 ```
 
-An [emptyDisk volume](http://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=emptydisk) creates an extra qcow2 disk that is created with the virtual machine. It will be removed if the `VirtualMachine` object is deleted.
+An [emptyDisk volume](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#emptydisk) creates an extra qcow2 disk that is created with the virtual machine. It will be removed if the `VirtualMachine` object is deleted.
 
 ```yaml
 emptyDisk:
   capacity: string
 ```
 
-[Ephemeral volume](http://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=ephemeral) creates a temporary local copy on write image storage that will be discarded when the `VirtualMachine` is removed.
+[Ephemeral volume](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#ephemeral) creates a temporary local copy on write image storage that will be discarded when the `VirtualMachine` is removed.
 
 ```yaml
 ephemeral:
@@ -306,7 +306,7 @@ ephemeral:
 name: string
 ```
 
-[persistentVolumeClaim volume](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=persistentvolumeclaim) persists after the `VirtualMachine` is deleted.
+[persistentVolumeClaim volume](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#persistentvolumeclaim) persists after the `VirtualMachine` is deleted.
 
 ```yaml
 persistentVolumeClaim:
@@ -314,7 +314,7 @@ persistentVolumeClaim:
   readOnly: true
 ```
 
-[registryDisk volume](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=containerdisk) type uses a virtual machine disk that is stored in a container image registry.
+[registryDisk volume](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) type uses a virtual machine disk that is stored in a container image registry.
 
 ```yaml
 registryDisk:
@@ -324,7 +324,7 @@ registryDisk:
 
 ### Virtual Machine Status
 
-Once the `VirtualMachine` object has been created the [VirtualMachineStatus](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_virtualmachinestatus) will be available. [VirtualMachineStatus](http://kubevirt.io/api-reference/v0.4.1/definitions.html#_v1_virtualmachinestatus) can be used in automation tools such as Ansible to confirm running state, determine where a `VirtualMachine` is running via `nodeName` or the `ipAddress` of the virtual machine operating system.
+Once the `VirtualMachine` object has been created the [VirtualMachineStatus](http://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinestatus) will be available. [VirtualMachineStatus](http://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachinestatus) can be used in automation tools such as Ansible to confirm running state, determine where a `VirtualMachine` is running via `nodeName` or the `ipAddress` of the virtual machine operating system.
 
     kubectl -o yaml get vm mongodb -n nodejs-ex
 
@@ -342,7 +342,7 @@ Example using `--template` to retrieve the `.status.phase` of the `VirtualMachin
 
 ### Examples
 
-- <https://kubevirt.io/user-guide/#/creation/creating-virtual-machines?id=virtualmachineinstance-api>
+- <https://kubevirt.io/user-guide/virtual_machines/virtual_machine_instances/#virtualmachineinstance-api>
 
 ## OfflineVirtualMachine
 
@@ -382,7 +382,7 @@ spec:
 
 ### What is Running in OfflineVirtualMachine?
 
-[.spec.running](https://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_offlinevirtualmachinespec) controls whether the associated VirtualMachine object is created. In other words this changes the [power status](https://kubevirt.io/user-guide/#/usage/life-cycle?id=stopping-a-virtual-machine) of the virtual machine.
+[.spec.running](https://kubevirt.io/api-reference/master/definitions.html#_v1_offlinevirtualmachinespec) controls whether the associated VirtualMachine object is created. In other words this changes the [power status](https://kubevirt.io/user-guide/virtual_machines/lifecycle/#stopping-a-virtual-machine) of the virtual machine.
 
       running: true
 
@@ -405,7 +405,7 @@ a guest.
 
 ### Offline Virtual Machine Status
 
-Once the `OfflineVirtualMachine` object has been created the [OfflineVirtualMachineStatus](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_offlinevirtualmachinestatus) will be available. Like `VirtualMachineStatus` `OfflineVirtualMachineStatus` can be used for automation tools such as Ansible.
+Once the `OfflineVirtualMachine` object has been created the [OfflineVirtualMachineStatus](http://kubevirt.io/api-reference/master/definitions.html#_v1_offlinevirtualmachinestatus) will be available. Like `VirtualMachineStatus` `OfflineVirtualMachineStatus` can be used for automation tools such as Ansible.
 
     kubectl -o yaml get ovms mongodb -n nodejs-ex
 
@@ -421,7 +421,7 @@ Example using `--template` to retrieve the `.status.conditions[0].type` of `Offl
 
 ## VirtualMachineReplicaSet
 
-[VirtualMachineReplicaSet](https://kubevirt.io/user-guide/#/usage/virtual-machine-replica-set) is great when you want to run multiple identical virtual machines.
+[VirtualMachineReplicaSet](https://kubevirt.io/user-guide/virtual_machines/replicaset/) is great when you want to run multiple identical virtual machines.
 
 Just like the other top-level objects we can retrieve `VirtualMachineReplicaSet`.
 
@@ -438,17 +438,17 @@ With the `replicas` parameter set to `2` the command below displays the two `Vir
 
 ### Pause rollout
 
-The [.spec.paused](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_vmreplicasetspec) parameter if true pauses the deployment of the `VirtualMachineReplicaSet`.
+The [.spec.paused](http://kubevirt.io/api-reference/master/definitions.html#_v1_vmreplicasetspec) parameter if true pauses the deployment of the `VirtualMachineReplicaSet`.
 
       paused: true
 
 ### Replica quantity
 
-The [.spec.replicas](https://kubevirt.io/user-guide/#/usage/virtual-machine-replica-set?id=how-to-use-a-virtualmachineinstancereplicaset) number of `VirtualMachine` objects that should be created.
+The [.spec.replicas](https://kubevirt.io/user-guide/virtual_machines/replicaset/#using-virtualmachineinstancereplicaset) number of `VirtualMachine` objects that should be created.
 
       replicas: 0
 
-The [selector](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_labelselector) must be defined and match labels defined in the template. It is used by the controller to keep track of managed virtual machines.
+The [selector](http://kubevirt.io/api-reference/master/definitions.html#_v1_labelselector) must be defined and match labels defined in the template. It is used by the controller to keep track of managed virtual machines.
 
 ```yaml
 selector:
@@ -460,7 +460,7 @@ selector:
   matchLabels: {}
 ```
 
-### [Virtual Machine Template Spec](https://kubevirt.io/user-guide/#/usage/virtual-machine-replica-set?id=how-to-use-a-virtualmachineinstancereplicaset)
+### [Virtual Machine Template Spec](https://kubevirt.io/user-guide/virtual_machines/replicaset/#using-virtualmachineinstancereplicaset)
 
 The `VMTemplateSpec` is the definition of a `VirtualMachine` objects that will be created.
 
@@ -478,7 +478,7 @@ template:
 
 ### Replica Status
 
-Like the other objects we already have discussed [VMReplicaSetStatus](http://kubevirt.io/api-reference/v0.5.0/definitions.html#_v1_vmreplicasetstatus) is an important object to use for automation.
+Like the other objects we already have discussed [VMReplicaSetStatus](http://kubevirt.io/api-reference/master/definitions.html#_v1_vmreplicasetstatus) is an important object to use for automation.
 
 ```yaml
 status:
@@ -495,7 +495,7 @@ Example using `--template` to retrieve the `.status.readyReplicas` and `.status.
 
 ### Examples
 
-- <https://kubevirt.io/user-guide/#/usage/virtual-machine-replica-set?id=example>
+- <https://kubevirt.io/user-guide/virtual_machines/replicaset/#example>
 
 ## VirtualMachinePreset
 
@@ -516,7 +516,7 @@ See the `VirtualMachine` section above for annotated details of the `DomainSpec`
 
 ### Preset Selector
 
-The [selector](https://kubevirt.io/user-guide/#/creation/presets?id=virtualmachine-selector) is optional but if not defined will be applied to all `VirtualMachine` objects; which is probably not the intended purpose so I recommend always including a selector.
+The [selector](https://kubevirt.io/user-guide/virtual_machines/presets/#virtualmachine-selector) is optional but if not defined will be applied to all `VirtualMachine` objects; which is probably not the intended purpose so I recommend always including a selector.
 
 ```yaml
 selector:
@@ -530,6 +530,6 @@ selector:
 
 ### Examples
 
-- <https://kubevirt.io/user-guide/#/creation/presets?id=examples>
+- <https://kubevirt.io/user-guide/virtual_machines/presets/#examples>
 
 We provided an annotated view into the KubeVirt objects - VirtualMachine, OfflineVirtualMachine, VirtualMachineReplicaSet and VirtualMachinePreset. Hopefully this will help a user of KubeVirt to understand the options and parameters that are currently available when creating a virtual machine on Kubernetes.

--- a/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
+++ b/_posts/2018-05-16-KubeVirt-API-Access-Control.markdown
@@ -178,4 +178,4 @@ these roles will prevent admins from ever having to create their own custom
 KubeVirt RBAC roles.
 
 More information about these default roles can be found in the KubeVirt
-user guide [here](https://kubevirt.io/user-guide/#/authorization)
+user guide [here](https://kubevirt.io/user-guide/operations/authorization/)

--- a/_posts/2018-11-16-new-volume-types.markdown
+++ b/_posts/2018-11-16-new-volume-types.markdown
@@ -146,4 +146,4 @@ default
 ## Summary
 
 With these new volume types KubeVirt further improves the integration with native Kubernetes resources.
-Learn more about all available volume types on the [userguide](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes).
+Learn more about all available volume types on the [userguide](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes).

--- a/_posts/2019-01-22-An-overview-to-KubeVirt-metrics.markdown
+++ b/_posts/2019-01-22-An-overview-to-KubeVirt-metrics.markdown
@@ -98,7 +98,7 @@ In this blog post, we will explore the current state of integration between Kube
 
 ## Let's deploy KubeVirt and dig on the metrics components
 
-- Deploy KubeVirt using the [official documentation](https://kubevirt.io/user-guide/#/README).For this blog post the version _0.11.0_ has been used.
+- Deploy KubeVirt using the [official documentation](https://kubevirt.io/user-guide).  This blog post uses version _0.11.0_.
 - Metrics:
   - If you've installed KubeVirt before, there's a service that might be unfamiliar to you, _service/kubevirt-prometheus-metrics_, this service uses a selector set to match the label _prometheus.kubevirt.io: ""_ which is included on all the main KubeVirt components, like the _virt-api_, _virt-controllers_ and _virt-handler_.
   - The _kubevirt-prometheus-metrics_ also exposes the _metrics_ port set to _443_ so Promtheus can scrape the metrics for all the components through it.
@@ -135,7 +135,7 @@ In this blog post, we will explore the current state of integration between Kube
 
   The _rest_client_requests_total_, represents the number of HTTP requests, partitioned by status code, method, and host.
 
-- Now, following again [KubeVirt's docs](https://kubevirt.io/user-guide/#/installation/monitoring), we need to deploy two resources:
+- Now, following again [KubeVirt's docs](https://kubevirt.io/user-guide/operations/component_monitoring/), we need to deploy two resources:
 
   1. A [Prometheus resource](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#prometheus). Just copy the YAML snippet from _KubeVirt's docs_ and apply it as follows:
 

--- a/_posts/2019-03-14-More-about-Kubevirt-metrics.markdown
+++ b/_posts/2019-03-14-More-about-Kubevirt-metrics.markdown
@@ -266,7 +266,7 @@ We describe two of the most common pitfalls.
 
 #### create the servicemonitor in the right namespace
 
-KubeVirt services run in the `kubevirt` namespace. Make sure to [create the servicemonitor](https://kubevirt.io/user-guide/#/installation/monitoring?id=integrating-with-the-prometheus-operator) in the same namespace:
+KubeVirt services run in the `kubevirt` namespace. Make sure to [create the servicemonitor](https://kubevirt.io/user-guide/operations/component_monitoring/#integrating-with-the-prometheus-operator) in the same namespace:
 
 ```bash
 kubectl get pods -n kubevirt
@@ -292,7 +292,7 @@ kubevirt-prometheus-metrics   ClusterIP   10.109.85.101    <none>        443/TCP
 virt-api                      ClusterIP   10.109.162.102   <none>        443/TCP   19h
 ```
 
-See [the KubeVirt documentation](https://kubevirt.io/user-guide/#/installation/monitoring?id=custom-service-discovery) for all the details.
+See [the KubeVirt documentation](https://kubevirt.io/user-guide/operations/component_monitoring/#custom-service-discovery) for all the details.
 
 #### configure the Prometheus instance to look in the right namespace
 

--- a/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
+++ b/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
@@ -28,7 +28,7 @@ In this blog post we will show you how to deploy a VM as a yaml template and the
 
 - User is familiar with the concept of [KubeVirt-architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) and [CDI-architecture](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/design.md#design)
 
-- User has already installed KubeVirt in an available K8s environment, if not please follow the link [Installing KubeVirt](https://kubevirt.io/user-guide/#/installation/installation?id=installation) to further proceed.
+- User has already installed KubeVirt in an available K8s environment, if not please follow the link [Installing KubeVirt](https://kubevirt.io/user-guide/operations/installation/) to further proceed.
 
 - User is already familiar with VM operation with Kubernetes, for a refresher on how to use 'Virtual Machines' in Kubernetes, please do check [LAB 1]({% link labs/kubernetes/lab1.md %}) before proceeding.
 

--- a/_posts/2019-07-30-NodeDrain-KubeVirt.markdown
+++ b/_posts/2019-07-30-NodeDrain-KubeVirt.markdown
@@ -14,7 +14,7 @@ tags: [node drain, eviction, nmo]
 
 In a Kubernetes (k8s) cluster, the control plane(scheduler) is responsible for deploying workloads(`pods`, `deployments`, `replicasets`) on the worker nodes depending on the resource availability. What do we do with the workloads if the need arises for maintaining this node? Well, there is good news, `node-drain` feature and node maintenance operator(NMO) both come to our rescue in this situation.
 
-This post discusses evicting the [VMI](https://kubevirt.io/user-guide/#/creation/creating-virtual-machines?id=virtual-machines)(virtual machine images) and other resources from the node using node drain feature and NMO.
+This post discusses evicting the [VMI](https://kubevirt.io/user-guide/virtual_machines/virtual_machine_instances/#virtual-machines-instances)(virtual machine instance) and other resources from the node using node drain feature and NMO.
 
 > note "Note"
 > The environment used for writing this post is based on [OpenShift 4](https://cloud.redhat.com/openshift/install/aws/installer-provisioned) with 3 Masters and 3 Worker nodes.

--- a/_posts/2019-10-23-KubeVirt_k8s_crio_from_scratch_installing_KubeVirt.md
+++ b/_posts/2019-10-23-KubeVirt_k8s_crio_from_scratch_installing_KubeVirt.md
@@ -144,7 +144,7 @@ CAVEATS:
  |
  |  See
  |
- |    https://kubevirt.io/user-guide/#/usage/graphical-and-console-access?id=graphical-and-serial-console-access
+ |    https://kubevirt.io/user-guide/virtual_machines/graphical_and_console_access/
  |
  |  for a usage example
 /
@@ -232,5 +232,5 @@ Each step of this guide has a place where to look for possible issues, in genera
 - [Kubernetes pod-network configuration](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network)
 - [Kubectl cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
 - [Multus](https://github.com/intel/multus-cni)
-- [KubeVirt User Guide](https://kubevirt.io/user-guide/#/)
+- [KubeVirt User Guide](https://kubevirt.io/user-guide/)
 - [KubeVirt Katacoda scenarios](https://www.katacoda.com/kubevirt)

--- a/_posts/2019-10-30-KubeVirt_storage_rook_ceph.md
+++ b/_posts/2019-10-30-KubeVirt_storage_rook_ceph.md
@@ -606,7 +606,7 @@ NAME                       READY   STATUS              RESTARTS   AGE
 importer-centos-dv-8v6l5   0/1     ContainerCreating   0          12s
 ```
 
-Once that pods ends, the Virtual Machine can be started (in this case the virt parameter can be used because of the [krew plugin system](https://kubevirt.io/user-guide/#/installation/virtctl?id=retrieving-the-virtctl-client-tool):
+Once that pods ends, the Virtual Machine can be started (in this case the virt parameter can be used because of the [krew plugin system](https://kubevirt.io/user-guide/operations/virtctl_client_tool/#retrieving-the-virtctl-client-tool):
 
 ```sh
 [root@kv-master-00 tmp]# kubectl virt start vm-centos-datavolume
@@ -721,4 +721,4 @@ sh-4.2# ceph status                                                             
 - [Ceph: free-software storage platform](https://ceph.io)
 - [Ceph hardware recommendations](https://docs.ceph.com/en/latest/start/hardware-recommendations/)
 - [Rook: Open-Source,Cloud-Native Storage for Kubernetes](https://rook.io/)
-- [KubeVirt User Guide](https://kubevirt.io/user-guide/#/)
+- [KubeVirt User Guide](https://kubevirt.io/user-guide)

--- a/_posts/2019-11-28-KubeVirt_basic_operations_video.md
+++ b/_posts/2019-11-28-KubeVirt_basic_operations_video.md
@@ -28,7 +28,7 @@ In this video, we are showing how KubeVirt can be used from a beginner point of 
 
 ## Pre-requisites
 
-In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/#/installation/installation) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
+In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/operations/installation/) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
 Also, the `virtctl` command is already installed and available in the PATH.
 
 ## Video
@@ -48,5 +48,5 @@ The following operations are shown in the video:
 ## References
 
 - [KubeVirt basic operations video on youtube](https://www.youtube.com/watch?v=KC03G60shIc)
-- [Kubevirt installation notes](https://kubevirt.io/user-guide/#/installation/installation)
+- [Kubevirt installation notes](https://kubevirt.io/user-guide/operations/installation/)
 - [First steps with KubeVirt - Katacoda scenario](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101)

--- a/_posts/2019-12-04-KubeVirt_lab1_use_kubevirt.md
+++ b/_posts/2019-12-04-KubeVirt_lab1_use_kubevirt.md
@@ -15,7 +15,7 @@ In this video, we are showing the step by step of the [KubeVirt Laboratory 1: Us
 
 ## Pre-requisites
 
-In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/#/installation/installation) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
+In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/operations/installation) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
 Also, the `virtctl` command is already installed and available in the PATH.
 
 ## Video
@@ -35,5 +35,5 @@ The following operations are shown in the video:
 
 - [Kubevirt Laboratory 1: Use KubeVirt instructions]({% link labs/kubernetes/lab1.md %})
 - [KubeVirt basic operations video on youtube](https://www.youtube.com/watch?v=KC03G60shIc)
-- [Kubevirt installation notes](https://kubevirt.io/user-guide/#/installation/installation)
+- [Kubevirt installation notes](https://kubevirt.io/user-guide/operations/installation/)
 - [First steps with KubeVirt - Katacoda scenario](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101)

--- a/_posts/2019-12-10-KubeVirt_lab2_experiment_with_cdi.md
+++ b/_posts/2019-12-10-KubeVirt_lab2_experiment_with_cdi.md
@@ -15,7 +15,7 @@ In this video, we are showing the step by step of the [KubeVirt Laboratory 2: Ex
 
 ## Pre-requisites
 
-In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/#/installation/installation) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
+In the video, there is a Kubernetes cluster together with KubeVirt already running. If you need help for preparing that setup you can check the [KubeVirt installation notes](https://kubevirt.io/user-guide/operations/installation/) or try it yourself in the [First steps with KubeVirt](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101) Katacoda scenario.
 Also, the `virtctl` command is already installed and available in the PATH.
 
 ## Video
@@ -39,5 +39,5 @@ The following operations are shown in the video:
 - [Kubevirt Laboratory 1 blogpost: Use Kubevirt]({% post_url 2019-12-04-KubeVirt_lab1_use_kubevirt %})
 - [Kubevirt Laboratory 1: Use KubeVirt]({% link labs/kubernetes/lab1.md %})
 - [KubeVirt basic operations video on youtube](https://www.youtube.com/watch?v=KC03G60shIc)
-- [Kubevirt installation notes](https://kubevirt.io/user-guide/#/installation/installation)
+- [Kubevirt installation notes](https://kubevirt.io/user-guide/operations/installation)
 - [First steps with KubeVirt - Katacoda scenario](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101)

--- a/_posts/2020-01-21-KubeVirt_lab3_upgrade.md
+++ b/_posts/2020-01-21-KubeVirt_lab3_upgrade.md
@@ -39,5 +39,5 @@ The following operations are shown in the video:
 - [Kubevirt Laboratory 1 blogpost: Use Kubevirt]({% post_url 2019-12-04-KubeVirt_lab1_use_kubevirt %})
 - [Kubevirt Laboratory 1: Use KubeVirt]({% link labs/kubernetes/lab1.md %})
 - [KubeVirt basic operations video on youtube](https://www.youtube.com/watch?v=KC03G60shIc)
-- [Kubevirt installation notes](https://kubevirt.io/user-guide/#/installation/installation)
+- [Kubevirt installation notes](https://kubevirt.io/user-guide/operations/installation/)
 - [First steps with KubeVirt - Katacoda scenario](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101)

--- a/_posts/2020-01-24-OKD-web-console-install.md
+++ b/_posts/2020-01-24-OKD-web-console-install.md
@@ -478,5 +478,5 @@ Ping us or feel free to comment this post in case there are some other existing 
 - [Managing KubeVirt with OpenShift web console running as a compiled binary on Youtube](https://www.youtube.com/watch?v=XQw4GkGHs44&t=37s)
 - [Kubevirt Laboratory 1 blogpost: Use Kubevirt]({% post_url 2019-12-04-KubeVirt_lab1_use_kubevirt %})
 - [KubeVirt basic operations video on Youtube](https://www.youtube.com/watch?v=KC03G60shIc)
-- [Kubevirt installation notes](https://kubevirt.io/user-guide/#/installation/installation)
+- [Kubevirt installation notes](https://kubevirt.io/user-guide/operations/installation)
 - [First steps with KubeVirt - Katacoda scenario](https://www.katacoda.com/kubevirt/scenarios/kubevirt-101)

--- a/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
+++ b/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
@@ -27,7 +27,7 @@ In this blogpost, we are going to explain how to prepare that VM with the ISO fi
 ## Pre-requisites
 
 - A Kubernetes cluster is already up and running
-- [KubeVirt](https://kubevirt.io/user-guide/#/) and [CDI](https://github.com/kubevirt/containerized-data-importer/blob/master/README.md) are already installed
+- [KubeVirt](https://kubevirt.io/user-guide) and [CDI](https://github.com/kubevirt/containerized-data-importer/blob/master/README.md) are already installed
 - There is enough free CPU, Memory and disk space in the cluster to deploy a Microsoft Windows VM, in this example, the version 2012 R2 VM is going to be used
 
 ## Preparation
@@ -128,7 +128,7 @@ To proceed with the Installation steps the different elements involved are liste
    storageClassName: hostpath
    ```
 
-4. A [container with the virtio drivers](https://kubevirt.io/user-guide/#/creation/virtio-win?id=how-to-obtain-virtio-drivers) attached as a CD-ROM to the VM.
+4. A [container with the virtio drivers](https://kubevirt.io/user-guide/virtual_machines/windows_wirtio_drivers/#how-to-obtain-virtio-drivers) attached as a CD-ROM to the VM.
    The container image has to be pulled to have it available in the local registry.
 
    ```sh
@@ -285,7 +285,7 @@ Once the Virtual Machine is created, the PVC with the ISO and the `virtio` drive
 
 ## References
 
-- [KubeVirt user-guide: Virtio Windows Driver disk usage](https://kubevirt.io/user-guide/#/creation/virtio-win)
+- [KubeVirt user-guide: Virtio Windows Driver disk usage](https://kubevirt.io/user-guide/virtual_machines/windows_wirtio_drivers/)
 - [Creating a registry image with a VM disk](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/image-from-registry.md)
 - [CDI Upload User Guide](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/upload.md)
-- [KubeVirt user-guide: How to obtain virtio drivers?](https://kubevirt.io/user-guide/#/creation/virtio-win?id=how-to-obtain-virtio-drivers)
+- [KubeVirt user-guide: How to obtain virtio drivers?](https://kubevirt.io/user-guide/virtual_machines/windows_wirtio_drivers/#how-to-obtain-virtio-drivers)

--- a/_posts/2020-02-25-Advanced-scheduling-with-affinity-rules.md
+++ b/_posts/2020-02-25-Advanced-scheduling-with-affinity-rules.md
@@ -21,7 +21,7 @@ pub-date: February 25
 pub-year: 2020
 ---
 
-This blog post shows how KubeVirt can take advantage of Kubernetes inner features to provide an advanced scheduling mechanism to virtual machines (VMs). The same or even more complex [affinity and anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) rules can be assigned to VMs or Pods in Kubernetes than in traditional virtualization solutions.
+This blog post shows how KubeVirt can take advantage of Kubernetes inner features to provide an advanced scheduling mechanism to virtual machines (VMs). The same or even more complex [affinity and anti-affinity](https://kubevirt.io/user-guide/operations/node_assignment/#affinity-and-anti-affinity) rules can be assigned to VMs or Pods in Kubernetes than in traditional virtualization solutions.
 
 It is important to notice that from the Kubernetes scheduler stand point, which will be explained later, it only manages Pod and node scheduling. Since the VM is wrapped up in a Pod, the same scheduling rules are completely valid to KubeVirt VMs.
 
@@ -55,7 +55,7 @@ In this example, our mission is to run a customapp that is composed of 3 tiers:
 Instructions were delivered to deploy the application in our production Kubernetes cluster taking advantage of the existing KubeVirt integration and making sure the application is resilient to any problems that can occur. The current status of the cluster is the following:
 
 - A stretched Kubernetes cluster is already up and running.
-- [KubeVirt](https://kubevirt.io/user-guide/#/) is already installed.
+- [KubeVirt](https://kubevirt.io/user-guide) is already installed.
 - There is enough free CPU, Memory and disk space in the cluster to deploy customapp stack.
 
 > info "information"

--- a/_posts/2020-03-22-Live-migration.md
+++ b/_posts/2020-03-22-Live-migration.md
@@ -240,6 +240,6 @@ As a briefing on the above data:
 
 ## References
 
-- [Live Migration](https://kubevirt.io/user-guide/#/installation/live-migration?id=live-migration)
-- [Node Drain/Eviction](https://kubevirt.io/user-guide/#/installation/node-eviction?id=how-to-evict-all-vms-on-a-node)
+- [Live Migration](https://kubevirt.io/user-guide/operations/live_migration/)
+- [Node Drain/Eviction](https://kubevirt.io/user-guide/operations/node_maintenance/#evict-all-vms-from-a-node)
 - [Rook](https://rook.io/)

--- a/_posts/2020-05-12-KubeVirt-VM-Image-Usage-Patterns.md
+++ b/_posts/2020-05-12-KubeVirt-VM-Image-Usage-Patterns.md
@@ -46,8 +46,8 @@ For our purposes in this workflow, the base image is meant to be immutable. No V
 
 I’m not covering this. Use our documentation linked to below. Understand that CDI (containerized data importer) is the tool we’ll be using to help populate and manage PVCs.
 
-[Installing KubeVirt](https://kubevirt.io/user-guide/#/installation/installation)
-[Installing CDI](https://kubevirt.io/user-guide/#/installation/image-upload?id=install-cdi)
+[Installing KubeVirt](https://kubevirt.io/user-guide/operations/installation)
+[Installing CDI](https://kubevirt.io/user-guide/operations/containerized_data_importer)
 
 ### Step 1. Create a namespace for our immutable VM images.
 
@@ -328,7 +328,7 @@ spec:
         storage: 5Gi
 ```
 
-Next, create a VirtualMachineInstanceReplicaSet that references the nginx-rom PVC as an ephemeral volume. With an ephemeral volume, KubeVirt will mount the PVC read only, and use a cow (copy on write) [ephemeral volume](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=ephemeral) on local storage to back each individual VMI. This ephemeral data’s life cycle is limited to the life cycle of each VMI.
+Next, create a VirtualMachineInstanceReplicaSet that references the nginx-rom PVC as an ephemeral volume. With an ephemeral volume, KubeVirt will mount the PVC read only, and use a cow (copy on write) [ephemeral volume](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#ephemeral) on local storage to back each individual VMI. This ephemeral data’s life cycle is limited to the life cycle of each VMI.
 
 Here’s an example manifest of a VirtualMachineInstanceReplicaSet starting 5 instances of our nginx server in separate VMIs.
 

--- a/_posts/2020-05-25-SELinux-from-basics-to-KubeVirt.md
+++ b/_posts/2020-05-25-SELinux-from-basics-to-KubeVirt.md
@@ -26,7 +26,7 @@ For an overview of KubeVirt security, please first read [this excellent article]
 
 ## SELinux 101
 
-At its core, SELinux is a whitelist-based security policy system intended to limit interactions between Linux processes and files. Simplified, it can be visualized as a "syscall firewall".
+At its core, SELinux is a allow list-based security policy system intended to limit interactions between Linux processes and files. Simplified, it can be visualized as a "syscall firewall".
 
 Policies are based on statically defined types, that can be assigned to files, processes and other objects.
 
@@ -39,7 +39,7 @@ The policy for that would include directives to:
 
 ## The SELinux standard Reference Policy
 
-Since SELinux policies are whitelists, a setup running with the above policy would not be allowed to do anything, except for that test program.
+Since SELinux policies are allow lists, a setup running with the above policy would not be allowed to do anything, except for that test program.
 
 A policy for an entire Linux distribution as seen in the wild is made of millions of lines, which wouldn't be practical to write and maintain on a per-distribution basis.
 

--- a/_posts/2020-06-22-win_workload_in_k8s.md
+++ b/_posts/2020-06-22-win_workload_in_k8s.md
@@ -40,7 +40,7 @@ Kubernetes and KubeVirt on a Fedora Linux host.  Yes!  It can be done!</p>
 
 * Host platform: Fedora 32 with latest updates applied
 * Kubernetes cluster created
-* [KubeVirt](https://kubevirt.io/quickstart_minikube/) and [CDI](https://kubevirt.io/user-guide/#/installation/image-upload) installed in the Kubernetes cluster.
+* [KubeVirt](https://kubevirt.io/quickstart_minikube/) and [CDI](https://kubevirt.io/user-guide/operations/containerized_data_importer/) installed in the Kubernetes cluster.
 
 ## Procedure
 

--- a/_posts/2020-12-10-Customizing-images-for-containerized-vms.md
+++ b/_posts/2020-12-10-Customizing-images-for-containerized-vms.md
@@ -71,7 +71,7 @@ This goal is divided into three main procedures:
 
 ## Preparation of the environment
 
-Running containerized VMs in KubeVirt uses the [containerDisk](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?id=containerdisk) feature which provides the ability to store and distributed VM disks in the container image registry. The disks are pulled from the container registry and reside on the local node hosting the VMs that consume the disks.
+Running containerized VMs in KubeVirt uses the [containerDisk](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) feature which provides the ability to store and distributed VM disks in the container image registry. The disks are pulled from the container registry and reside on the local node hosting the VMs that consume the disks.
 
 The company already have an [OKD 4 Kubernetes cluster](https://www.okd.io/) installed which provides out of the box a container registry and some required security features such as _Role Based Access Controls (RBAC)_ and _Security Context Constraints (SCC)_.
 
@@ -649,7 +649,7 @@ Please contact us at sysadmin@corporate.com
 
 In the previous section, we verified that the golden image was successfully built. However, there are still a few things that need to be added so that the golden image can be successfully containerized and run on top of our OKD Kubernetes cluster.
 
-First, a worthy package that is suggested to be included in the golden image is [cloud-init](https://cloud-init.io/). KubeVirt allows you to create VM objects along with [cloud-init](https://kubevirt.io/user-guide/#/creation/cloud-init?id=startup-scripts) configurations. Cloud-init will let our developers further adapt the custom image to their application needs. On the other hand, it has been agreed with the Software Engineering team to add a graphical interface to the custom image since there are developers that are not familiar with the terminal.
+First, a worthy package that is suggested to be included in the golden image is [cloud-init](https://cloud-init.io/). KubeVirt allows you to create VM objects along with [cloud-init](https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#cloud-init) configurations. Cloud-init will let our developers further adapt the custom image to their application needs. On the other hand, it has been agreed with the Software Engineering team to add a graphical interface to the custom image since there are developers that are not familiar with the terminal.
 
 The result will be **two golden images CentOS 8**, both with cloud-init, but one will include a GUI and the other is terminal-based and therefore much lighter.
 
@@ -753,7 +753,7 @@ At this point we built:
 
 ## Image containerization procedure
 
-The procedure to inject a *VirtualMachineInstance* disk into a container images is pretty well explained in [containerDisk Workflow example](https://kubevirt.io/user-guide/#/creation/disks-and-volumes?) from the official documentation. Only RAW and QCOW2 formats are supported and the disk it is recommended to be placed into the /disk directory inside the container. Actually, it can be placed in other directories, but then, it must be explicitly configured when creating the *VirtualMachine*
+The procedure to inject a *VirtualMachineInstance* disk into a container images is pretty well explained in [containerDisk Workflow example](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes) from the official documentation. Only RAW and QCOW2 formats are supported and the disk it is recommended to be placed into the /disk directory inside the container. Actually, it can be placed in other directories, but then, it must be explicitly configured when creating the *VirtualMachine*
 
 Currently, there are 4 standardized images ready to be containerized. The process is the same for all of them, so in order to keep it short, we are just going to show the process of creating a container image from the CentOS 8 QCOW2 images.
 

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -23,7 +23,7 @@ You can experiment this lab online at [![Katacoda](/assets/images/katacoda-logo.
 
 ### Create a Virtual Machine
 
-Download the VM manifest and explore it. Note it uses a [registry disk](https://kubevirt.io/user-guide/#/workloads/virtual-machines/disks-and-volumes?id=registrydisk) and as such doesn't persist data. Such registry disks currently exist for alpine, cirros and fedora.
+Download the VM manifest and explore it. Note it uses a [container disk](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) and as such doesn't persist data. Such container disks currently exist for alpine, cirros and fedora.
 
 ```bash
 {% include scriptlets/lab1/01_get_vm_manifest.sh -%}

--- a/labs/kubernetes/lab3.md
+++ b/labs/kubernetes/lab3.md
@@ -148,7 +148,7 @@ Once the PHASE will change to `Running`, we're ready for upgrading KubeVirt.
 
 #### Define the next version to upgrade to
 
-KubeVirt starting from `v0.17.0` onwards, allows to upgrade one version at a time, by using two approaches as defined in the [user-guide](https://kubevirt.io/user-guide/#/installation/updating-and-deleting-installs):
+KubeVirt starting from `v0.17.0` onwards, allows to upgrade one version at a time, by using two approaches as defined in the [user-guide](https://kubevirt.io/user-guide/operations/updating_and_deletion):
 
 - Patching the imageTag value in the KubeVirt CR spec
 - Updating the operator if no imageTag is defined (defaulting to upgrade to match the operator version)


### PR DESCRIPTION
**Does this PR fix any issue?**
This fixes website content containing broken links to user-guide as well as long time standing broken selectors.

Near two broken links I found two instances of emotionally charged words.  They're one word changes.  More info [here](https://www.redhat.com/en/blog/update-red-hats-conscious-language-efforts) on why we need to be diligent about the choice of words we use.