### PR TITLE
Increase the PVC size to host the Fedora image

### DIFF
--- a/labs/manifests/pvc_fedora.yml
+++ b/labs/manifests/pvc_fedora.yml
@@ -11,5 +11,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 4Gi
+      storage: 5Gi
   storageClassName: hostpath


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The virtual size of the Fedora cloud image is 4 GiB:

```console
$ qemu-img info https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2
image: https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2
file format: qcow2
virtual size: 4 GiB (4294967296 bytes)
disk size: unavailable
cluster_size: 65536
Format specific information:
    compat: 0.10
    compression type: zlib
    refcount bits: 16
```

and this causes the image importer to fail with the currently requested 4GiB PVC size (need to account for the small overhead):

```
E0223 08:15:08.906080       1 data-processor.go:238] Virtual image size 4294967296 is larger than available size 4058744094 (PVC size 4294967296, reserved overhead 0.055000%). A larger PVC is required.
Unable to convert source data to target format
```

This changes the requested PVC size to 5GiB instead.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

Fixes #693
