### PR TITLE
Update description field for 2021-04-30-intel-vgpu-kubevirt blog post

### DIFF
--- a/_posts/2021-04-30-intel-vgpu-kubevirt.md
+++ b/_posts/2021-04-30-intel-vgpu-kubevirt.md
@@ -2,7 +2,7 @@
 layout: post
 author: Mark DeNeve
 title: Using Intel vGPUs with Kubevirt
-description: Excerpt of the Blog Post
+description: This blog post guides users on how to improve VM graphics performance using Intel Core processors, GPU Virtualization and Kubevirt.
 navbar_active: Blogs
 pub-date: April 30
 pub-year: 2021


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an oversight in the blog post where I left the "example" description for the blog post in place. Current description does not look good on blog post listing page.

