### PR TITLE
typo fix and updates to test work section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ git checkout master; git fetch upstream; git reset --hard upstream/master; git p
 *Note* Master branch is purely cosmetic for this repo. Merges to master **ARE NOT ACCEPTED**.
 
 
-All work must be branched from `maaster` branch. Perform the following to sync from upstream ...
+All work must be branched from `master` branch. Perform the following to sync from upstream ...
 
 ```bash
 git checkout master; git fetch upstream; git reset --hard upstream/master; git push origin master -f
@@ -141,12 +141,12 @@ Open your web browser to http://0.0.0.0:4000
 
 3) Test all hyperlinks
 ```bash
-make test_links
+make check_links
 ```
 
 4) Test spelling
 ```bash
-make test_spelling
+make check_spelling
 ```
 
 If you discover a flagged spelling error that you believe is not a mistake, feel free to add the offending word to the dictionary file located at GitHub repo `kubevirt/project-infra/images/yaspeller/.yaspeller.json`. Try to keep the dictionary file well ordered and employ regular expressions to handle common patterns.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a typo in the Readme, and also updates the section on running tests. The instructions say to run "test_links" and "test_spelling", however the make commands are "check_links" and "check_spelling".  Commands were tested to ensure that they work.

Signed-off-by: Mark DeNeve <markd@xphyr.net>