### PR TITLE
Add check_lint markdown target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ else
 endif
 endif
 
+ifndef LINT_IMAGE
+	@$(eval export LINT_IMAGE=quay.io/tauerbec/markdownlint-cli:latest)
+endif
 
 ## Build site. This target should only be used by Netlify and Prow
 build: envvar
@@ -211,3 +214,9 @@ stop: | envvar
 	@echo "${GREEN}Makefile: Stop running container${RESET}"
 	${CONTAINER_ENGINE} rm -f website 2> /dev/null; echo
 	@echo -n
+
+check_lint: | envvar
+	@echo "${GREEN}Makefile: Linting Markdown files using ${LINT_IMAGE}${RESET}"
+	${CONTAINER_ENGINE} run -it --rm -v ${PWD}:/src:ro${SELINUX_ENABLED} --workdir /src ${LINT_IMAGE} **/*.md
+	@echo
+


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `check_lint` markdown target to the Makefile in order lint all of the `*.md` files in the repository.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #652 

**Special notes for your reviewer**:

@mazzystr Tried to pick up some of the notes from #719. Figured this would be a good starting point. The current `LINT_IMAGE` is just a stand-in for now until https://github.com/igorshubovych/markdownlint-cli/pull/208 (hopefully) gets merged. 