### PR TITLE
Update KubeVirt refs master -> main

### DIFF
--- a/_posts/2018-04-25-KubeVirt-Network-Deep-Dive.markdown
+++ b/_posts/2018-04-25-KubeVirt-Network-Deep-Dive.markdown
@@ -182,7 +182,7 @@ Check the status of Skydive agent and analyzer
 
 ### ingress-nginx
 
-To provide external access our example NodeJS application we need to an ingress controller. For this example we are going to use [ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/master/deploy)
+To provide external access our example NodeJS application we need to an ingress controller. For this example we are going to use [ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/main/deploy)
 
 I created a simple script `ingress.sh` that follows the installation documentation for ingress-nginx with a couple minor modifications:
 
@@ -345,19 +345,19 @@ Now that we shown that kubernetes, kubevirt, ingress-nginx and flannel work toge
     </figure>
 </div>
 
-## virt-launcher - [virtwrap](https://github.com/kubevirt/kubevirt/tree/master/pkg/virt-launcher/virtwrap)
+## virt-launcher - [virtwrap](https://github.com/kubevirt/kubevirt/tree/main/pkg/virt-launcher/virtwrap)
 
 virt-launcher is the pod that runs the necessary components instantiate and run a virtual machine. We are only going to concentrate on the network portion in this post.
 
-### [virtwrap manager](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/manager.go)
+### [virtwrap manager](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/manager.go)
 
 Before the virtual machine is started the `preStartHook` will run `SetupPodNetwork`.
 
-### SetupPodNetwork → [SetupDefaultPodNetwork](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/network/network.go)
+### SetupPodNetwork → [SetupDefaultPodNetwork](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/network/network.go)
 
 This function calls three functions that are detailed below `discoverPodNetworkInterface`, `preparePodNetworkInterface` and `StartDHCP`
 
-#### [discoverPodNetworkInterface](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/network/network.go)
+#### [discoverPodNetworkInterface](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/network/network.go)
 
 This function gathers the following information about the pod interface:
 
@@ -371,7 +371,7 @@ This function gathers the following information about the pod interface:
 
 This is stored for later use in configuring DHCP.
 
-#### [preparePodNetworkInterfaces](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/network/network.go)
+#### [preparePodNetworkInterfaces](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/network/network.go)
 
 Once the current details of the pod interface have been stored following operations are performed:
 
@@ -389,7 +389,7 @@ Once the current details of the pod interface have been stored following operati
 
 This will provide libvirt a bridge to use for the virtual machine that will be created.
 
-#### StartDHCP → DHCPServer → [SingleClientDHCPServer](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go)
+#### StartDHCP → DHCPServer → [SingleClientDHCPServer](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go)
 
 This DHCP server only provides a single address to a client in this case the virtual machine that will be started. The network details - the IP address, gateway, routes, DNS servers and suffixes are taken from the pod which will be served to the virtual machine.
 

--- a/_posts/2018-06-07-Non-Dockerized-Build.markdown
+++ b/_posts/2018-06-07-Non-Dockerized-Build.markdown
@@ -41,7 +41,7 @@ Currently, the Makefile includes targets that address different things: building
 
 ### Prerequisites
 
-Best place to look for that is in the docker file definition for the build environment: [hack/docker-builder/Dockerfile](https://github.com/kubevirt/kubevirt/blob/master/hack/builder/Dockerfile)
+Best place to look for that is in the docker file definition for the build environment: [hack/docker-builder/Dockerfile](https://github.com/kubevirt/kubevirt/blob/main/hack/builder/Dockerfile)
 
 Note that not everything from there is needed for building, so the bare minimum on Fedora27 would be:
 
@@ -139,9 +139,9 @@ File has the following targets:
 
 - **bootstrap**: this is actually part of the prerequisites, but added all golang tool dependencies here, since this is agnostic of the running platform Should be called once
   - Note that the k8s code generators use specific version
-  - Note that these are not code dependencies, as they are handled by using a `vendor` directory, as well as the distclean, deps-install and deps-update targets in the [standard makefile](ttps://github.com/kubevirt/kubevirt/blob/master/Makefile)
-- **generate**: Calling [hack/generate.sh](https://github.com/kubevirt/kubevirt/blob/master/hack/generate.sh) script similarly to the [standard makefile](https://github.com/kubevirt/kubevirt/blob/master/Makefile). It builds all generators (under the `tools` directory) and use them to generate: test mocks, KubeVirt resources and test yamls
-- **apidocs**: this is similar to apidocs target in the [standard makefile](ttps://github.com/kubevirt/kubevirt/blob/master/Makefile)
+  - Note that these are not code dependencies, as they are handled by using a `vendor` directory, as well as the distclean, deps-install and deps-update targets in the [standard makefile](https://github.com/kubevirt/kubevirt/blob/main/Makefile)
+- **generate**: Calling [hack/generate.sh](https://github.com/kubevirt/kubevirt/blob/main/hack/generate.sh) script similarly to the [standard makefile](https://github.com/kubevirt/kubevirt/blob/main/Makefile). It builds all generators (under the `tools` directory) and use them to generate: test mocks, KubeVirt resources and test yamls
+- **apidocs**: this is similar to apidocs target in the [standard makefile](https://github.com/kubevirt/kubevirt/blob/main/Makefile)
 - **build**: this is building all product binaries, and then using a script ([copy-cmd.sh](../assets/2018-06-07-Non-Dockerized-Build/copy-cmd.sh), should be placed under: `hack`) to copy the binaries from their standard location into the `_out` directory, where the cluster management scripts expect them
 - **test**: building and running unit tests
   check: using similar code to the one used in the standard makefile: formatting files, fixing package imports and calling go vet

--- a/_posts/2018-07-03-Unit-Test-Howto.markdown
+++ b/_posts/2018-07-03-Unit-Test-Howto.markdown
@@ -12,7 +12,7 @@ tags: [unit testing]
 
 There are [way too many reasons](https://blog.codinghorror.com/i-pity-the-fool-who-doesnt-write-unit-tests/) to write unit tests, but my favorite one is: the freedom to hack, modify and improve the code without fear, and get quick feedback that you are on the right track.
 
-Of course, writing good integration tests (the stuff under the [tests](https://github.com/kubevirt/kubevirt/tree/master/tests) directory) is the best way to validate that everything works, but unit tests has great value as:
+Of course, writing good integration tests (the stuff under the [tests](https://github.com/kubevirt/kubevirt/tree/main/tests) directory) is the best way to validate that everything works, but unit tests has great value as:
 
 - They are much faster to run (~30 seconds in our case)
 - You get nice coverage reports with [coveralls](https://coveralls.io/github/kubevirt/kubevirt)
@@ -39,8 +39,8 @@ There are several frameworks we use to write unit tests:
 - If you need mocks for k8s objects and interfaces, use their framework. They have a tool called [client-gen](https://github.com/kubernetes/code-generator), which generates both the code and the mocks based on the defined APIs
   - The generated mock interfaces and objects of the k8s client are [here](https://github.com/kubernetes/client-go/blob/master/kubernetes/fake/clientset_generated.go). Note that they a use a different mechanism to control the mocked behavior than the one used in GoMock
   - Mocked actions are more are [here](https://github.com/kubernetes/client-go/tree/master/testing)
-- Unit test utilities are placed under [testutils](https://github.com/kubevirt/kubevirt/tree/master/pkg/testutils)
-- Some integration test utilities are also useful for unit testing, see this [file](https://github.com/kubevirt/kubevirt/blob/master/tests/utils.go)
+- Unit test utilities are placed under [testutils](https://github.com/kubevirt/kubevirt/tree/main/pkg/testutils)
+- Some integration test utilities are also useful for unit testing, see this [file](https://github.com/kubevirt/kubevirt/blob/main/tests/utils.go)
 - When testing interfaces, a mock HTTP server is usually needed. For that we use the [golang httptest package](https://golang.org/pkg/net/http/httptest/)
   - gomega also has a package called [ghttp](http://onsi.github.io/gomega/#ghttp-testing-http-clients) that could be used for same purpose
 

--- a/_posts/2018-08-08-kubevirtci.markdown
+++ b/_posts/2018-08-08-kubevirtci.markdown
@@ -18,7 +18,7 @@ We leverage kubevirtci for our CI process, but there’s more to the CI system t
 
 ## What it does
 
-In short: Deploys a Kubernetes (or OpenShift) cluster using QEMU Virtual Machines, that run inside Docker containers. First a base image is [provisioned](https://github.com/kubevirt/kubevirtci/blob/master/cluster-provision/k8s/provision.sh), this image contains a stock a Kubernetes node. Then one or more of these images are deployed in the target environment to make up the cluster.
+In short: Deploys a Kubernetes (or OpenShift) cluster using QEMU Virtual Machines, that run inside Docker containers. First a base image is [provisioned](https://github.com/kubevirt/kubevirtci/blob/main/cluster-provision/k8s/provision.sh), this image contains a stock a Kubernetes node. Then one or more of these images are deployed in the target environment to make up the cluster.
 
 ### Provisioning
 
@@ -39,7 +39,7 @@ To create a cluster, all one has to do is start up a number of containers, which
 
 ### How does it work?
 
-After the provision step, which has created a pre-built Kubernetes node in a virtual machine, the deployment step doesn’t happen all by itself. Starting up the cluster is handled by a cli application, aptly named [‘gocli’](https://github.com/kubevirt/kubevirtci/tree/master/cluster-provision/gocli).
+After the provision step, which has created a pre-built Kubernetes node in a virtual machine, the deployment step doesn’t happen all by itself. Starting up the cluster is handled by a cli application, aptly named [‘gocli’](https://github.com/kubevirt/kubevirtci/tree/main/cluster-provision/gocli).
 
 Gocli is a go application that contains the knowledge needed to start the cluster, make a node the master node, and then register the other nodes with the master node as compute nodes. It also does a few other nice things, like start a dnsmasq container for dns inside the cluster, and a docker registry container for images. It also can extract and update the kubeconfig for the cluster, to make it possible for external tools to interact with the cluster (such as kubectl). And it can of course shut down the cluster in an orderly fashion.
 

--- a/_posts/2018-09-12-attaching-to-multiple-networks.markdown
+++ b/_posts/2018-09-12-attaching-to-multiple-networks.markdown
@@ -170,7 +170,7 @@ ovs-vsctl add-br blue
 - To install the OVS CNI use:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/kubevirt/ovs-cni/master/examples/ovs-cni.yml
+$ kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/ovs-cni/main/examples/ovs-cni.yml
 ```
 
 - Create a `NetworkAttachmentDefinition` CRD for the "blue" bridge:
@@ -210,7 +210,7 @@ spec:
     }'
 ```
 
-- More information could be found in the [OVS CNI documentation](https://github.com/kubevirt/ovs-cni/blob/master/docs/deployment-on-arbitrary-cluster.md)
+- More information could be found in the [OVS CNI documentation](https://github.com/k8snetworkplumbingwg/ovs-cni/blob/main/docs/deployment-on-arbitrary-cluster.md)
 
 ## Deploy a Virtual Machine with 2 Interfaces
 

--- a/_posts/2018-10-09-containerized-data-importer.markdown
+++ b/_posts/2018-10-09-containerized-data-importer.markdown
@@ -25,7 +25,7 @@ This approach supports two main use-cases:
 - A cluster administrator can build an abstract registry of immutable images (referred to as "Golden Images") which can be cloned and later consumed by KubeVirt
 - An ad-hoc user (granted access) can import a VM image into their own namespace and feed this image directly to KubeVirt, bypassing the cloning step
 
-For an in depth look at the system and workflow, see the [Design](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/design.md#design) documentation.
+For an in depth look at the system and workflow, see the [Design](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/design.md#design) documentation.
 
 # Data Format
 
@@ -153,7 +153,7 @@ Edit the PVC above -
 - cdi.kubevirt.io/storage.import.endpoint: The full URL to the VM image in the format of: http://www.myUrl.com/path/of/data or s3://bucketName/fileName.
 - storageClassName: The default StorageClass will be used if not set. Otherwise, set to a desired StorageClass.
 
-Note: It is possible to use authentication when importing the image from the endpoint url. Please see [using secret during import](https://github.com/kubevirt/containerized-data-importer/blob/master/manifests/example/endpoint-secret.yaml)
+Note: It is possible to use authentication when importing the image from the endpoint url. Please see [using secret during import](https://github.com/kubevirt/containerized-data-importer/blob/main/manifests/example/endpoint-secret.yaml)
 
 ## Deploy the manifest yaml files
 

--- a/_posts/2019-04-17-Hyper-Converged-Operator.markdown
+++ b/_posts/2019-04-17-Hyper-Converged-Operator.markdown
@@ -17,7 +17,7 @@ This Blog assumes that the reader is aware of the concept of Operators and how i
 
 ## What it does?
 
-The goal of the hyperconverged-cluster-operator (HCO) is to provide a single entrypoint for multiple operators - [kubevirt](https://blog.openshift.com/a-first-look-at-kubevirt/), [cdi](http://kubevirt.io/2018/CDI-DataVolumes.html), [networking](https://github.com/kubevirt/cluster-network-addons-operator/blob/master/README.md), etc... - where users can deploy and configure them in a single object. This operator is sometimes referred to as a "meta operator" or an "operator for operators". Most importantly, this operator doesn't replace or interfere with OLM. It only creates operator CRs, which is the user's prerogative.
+The goal of the hyperconverged-cluster-operator (HCO) is to provide a single entrypoint for multiple operators - [kubevirt](https://blog.openshift.com/a-first-look-at-kubevirt/), [cdi](http://kubevirt.io/2018/CDI-DataVolumes.html), [networking](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/README.md), etc... - where users can deploy and configure them in a single object. This operator is sometimes referred to as a "meta operator" or an "operator for operators". Most importantly, this operator doesn't replace or interfere with OLM. It only creates operator CRs, which is the user's prerogative.
 
 ## How does it work?
 
@@ -223,7 +223,7 @@ virtualmachines.kubevirt.io                                      2019-05-07T20:2
 ## You can also read more about CDI, CNA, ssp-operator, web-ui and KubeVirt:
 
 - [CDI]({% post_url 2018-10-10-CDI-DataVolumes %})
-- [CNA](https://github.com/kubevirt/cluster-network-addons-operator/blob/master/README.md)
+- [CNA](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/README.md)
 - [KubeVirt]({% link pages/quickstart_minikube.md  %})
 - [ssp-operator](https://github.com/MarSik/kubevirt-ssp-operator)
 - [kubevirt-web-ui](https://github.com/kubevirt/web-ui)

--- a/_posts/2019-07-08-kubevirt-with-ansible-part-2.markdown
+++ b/_posts/2019-07-08-kubevirt-with-ansible-part-2.markdown
@@ -41,7 +41,7 @@ Virtual machines managed by KubeVirt are highly customizable. Among the features
   - [Examples, lots of examples](https://docs.ansible.com/ansible/latest/collections/community/general/kubevirt_vm_module.html#examples)
 - DataVolumes
   - [Introductory blog post]({% post_url 2018-10-10-CDI-DataVolumes %})
-  - [Upstream documentation](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/datavolumes.md)
+  - [Upstream documentation](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md)
 - Multus
   - [Introductory blog post]({% post_url 2018-09-12-attaching-to-multiple-networks %})
   - [GitHub repo](https://github.com/intel/multus-cni)

--- a/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
+++ b/_posts/2019-07-29-How-To-Import-VM-into-Kubevirt.markdown
@@ -26,7 +26,7 @@ In this blog post we will show you how to deploy a VM as a yaml template and the
 
 - Persistent Volume Claim (PVC) is a request for storage by a user. It is similar to a pod. Pods consume node resources and PVCs consume PV resources. Feel free to check more on [Persistent Volume Claim(PVC)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
 
-- User is familiar with the concept of [KubeVirt-architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) and [CDI-architecture](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/design.md#design)
+- User is familiar with the concept of [KubeVirt-architecture](https://github.com/kubevirt/kubevirt/blob/main/docs/architecture.md) and [CDI-architecture](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/design.md#design)
 
 - User has already installed KubeVirt in an available K8s environment, if not please follow the link [Installing KubeVirt](https://kubevirt.io/user-guide/operations/installation/) to further proceed.
 
@@ -54,7 +54,7 @@ The cdi-uploadproxy service must be accessible from outside the cluster. Here ar
 - [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 - [Route](https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html)
 
-We can take a look at example manifests [here](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/upload.md)
+We can take a look at example manifests [here](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/upload.md)
 
 The supported image formats are:
 

--- a/_posts/2019-08-01-KubeVirt-CR-Condition-Types-Rename.markdown
+++ b/_posts/2019-08-01-KubeVirt-CR-Condition-Types-Rename.markdown
@@ -31,7 +31,7 @@ These changes take effect immediately if you are deploying KubeVirt from the mas
 
 [0] https://github.com/kubevirt/kubevirt/pull/2548
 [1] https://github.com/kubevirt/hyperconverged-cluster-operator
-[2] https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md
+[2] https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/docs/conditions.md
 
 Best regards,
 ```
@@ -57,4 +57,4 @@ Check for more information on the following URL's
 
 - <https://github.com/kubevirt/kubevirt/pull/2548>
 - <https://github.com/kubevirt/hyperconverged-cluster-operator>
-- <https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md>
+- <https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/docs/conditions.md>

--- a/_posts/2020-01-24-OKD-web-console-install.md
+++ b/_posts/2020-01-24-OKD-web-console-install.md
@@ -170,14 +170,14 @@ source ./contrib/environment.sh
 
 ## Deploy KubeVirt using the Hyperconverged Cluster Operator (HCO)
 
-In order to ease the installation of KubeVirt, the unified operator called **[HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)** will be deployed. The goal of the hyperconverged-cluster-operator (HCO) is to provide a single entrypoint for multiple operators - [kubevirt](https://blog.openshift.com/a-first-look-at-kubevirt/), [cdi](http://kubevirt.io/2018/CDI-DataVolumes.html), [networking](https://github.com/kubevirt/cluster-network-addons-operator/blob/master/README.md), etc... - where users can deploy and configure them in a single object.
+In order to ease the installation of KubeVirt, the unified operator called **[HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)** will be deployed. The goal of the hyperconverged-cluster-operator (HCO) is to provide a single entrypoint for multiple operators - [kubevirt](https://blog.openshift.com/a-first-look-at-kubevirt/), [cdi](http://kubevirt.io/2018/CDI-DataVolumes.html), [networking](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/README.md), etc... - where users can deploy and configure them in a single object.
 
 This operator is sometimes referred to as a "meta operator" or an "operator for operators". Most importantly, this operator doesn't replace or interfere with OLM. It only creates operator CRs, which is the user's prerogative. More information about HCO can be found in the post published in this blog by Ryan Hallisey: [Hyper Converged Operator on OCP 4 and K8s(HCO)](https://kubevirt.io/2019/Hyper-Converged-Operator.html).
 
 The HCO repository provides plenty of information on how to install the operator. In this lab, it has been installed as [Using the HCO without OLM or Marketplace](https://github.com/kubevirt/hyperconverged-cluster-operator#using-the-hco-without-olm-or-marketplace), which basically executes this deployment script:
 
 ```sh
-$ curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/deploy.sh | bash
+$ curl https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/deploy.sh | bash
 + kubectl create ns kubevirt-hyperconverged
 namespace/kubevirt-hyperconverged created
 + namespaces=("openshift")
@@ -190,27 +190,27 @@ namespace/openshift created
 ++ kubectl config current-context
 + kubectl config set-context kubernetes-admin@kubernetes --namespace=kubevirt-hyperconverged
 Context "kubernetes-admin@kubernetes" modified.
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/cluster-network-addons00.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/cluster-network-addons00.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/networkaddonsconfigs.networkaddonsoperator.network.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/containerized-data-importer00.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/containerized-data-importer00.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/cdis.cdi.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/hco.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/hco.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/hyperconvergeds.hco.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/kubevirt00.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/kubevirt00.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/kubevirts.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/node-maintenance00.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/node-maintenance00.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/nodemaintenances.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance00.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/scheduling-scale-performance00.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/kubevirtcommontemplatesbundles.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance01.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/scheduling-scale-performance01.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/kubevirtmetricsaggregations.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance02.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/scheduling-scale-performance02.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/kubevirtnodelabellerbundles.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/scheduling-scale-performance03.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/scheduling-scale-performance03.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/kubevirttemplatevalidators.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/crds/v2vvmware.crd.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/v2vvmware.crd.yaml
 customresourcedefinition.apiextensions.k8s.io/v2vvmwares.kubevirt.io created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/cluster_role.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/cluster_role.yaml
 role.rbac.authorization.k8s.io/cluster-network-addons-operator created
 clusterrole.rbac.authorization.k8s.io/hyperconverged-cluster-operator created
 clusterrole.rbac.authorization.k8s.io/cluster-network-addons-operator created
@@ -218,14 +218,14 @@ clusterrole.rbac.authorization.k8s.io/kubevirt-operator created
 clusterrole.rbac.authorization.k8s.io/kubevirt-ssp-operator created
 clusterrole.rbac.authorization.k8s.io/cdi-operator created
 clusterrole.rbac.authorization.k8s.io/node-maintenance-operator created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/service_account.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/service_account.yaml
 serviceaccount/cdi-operator created
 serviceaccount/cluster-network-addons-operator created
 serviceaccount/hyperconverged-cluster-operator created
 serviceaccount/kubevirt-operator created
 serviceaccount/kubevirt-ssp-operator created
 serviceaccount/node-maintenance-operator created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/cluster_role_binding.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/cluster_role_binding.yaml
 rolebinding.rbac.authorization.k8s.io/cluster-network-addons-operator created
 clusterrolebinding.rbac.authorization.k8s.io/hyperconverged-cluster-operator created
 clusterrolebinding.rbac.authorization.k8s.io/cluster-network-addons-operator created
@@ -233,14 +233,14 @@ clusterrolebinding.rbac.authorization.k8s.io/kubevirt-operator created
 clusterrolebinding.rbac.authorization.k8s.io/kubevirt-ssp-operator created
 clusterrolebinding.rbac.authorization.k8s.io/cdi-operator created
 clusterrolebinding.rbac.authorization.k8s.io/node-maintenance-operator created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/operator.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/operator.yaml
 deployment.apps/hyperconverged-cluster-operator created
 deployment.apps/cluster-network-addons-operator created
 deployment.apps/virt-operator created
 deployment.apps/kubevirt-ssp-operator created
 deployment.apps/cdi-operator created
 deployment.apps/node-maintenance-operator created
-+ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/deploy/hco.cr.yaml
++ kubectl create -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/hco.cr.yaml
 hyperconverged.hco.kubevirt.io/hyperconverged-cluster created
 ```
 

--- a/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
+++ b/_posts/2020-02-14-KubeVirt-installing_Microsoft_Windows_from_an_iso.md
@@ -27,7 +27,7 @@ In this blogpost, we are going to explain how to prepare that VM with the ISO fi
 ## Pre-requisites
 
 - A Kubernetes cluster is already up and running
-- [KubeVirt](https://kubevirt.io/user-guide) and [CDI](https://github.com/kubevirt/containerized-data-importer/blob/master/README.md) are already installed
+- [KubeVirt](https://kubevirt.io/user-guide) and [CDI](https://github.com/kubevirt/containerized-data-importer/blob/main/README.md) are already installed
 - There is enough free CPU, Memory and disk space in the cluster to deploy a Microsoft Windows VM, in this example, the version 2012 R2 VM is going to be used
 
 ## Preparation
@@ -288,6 +288,6 @@ Once the Virtual Machine is created, the PVC with the ISO and the `virtio` drive
 ## References
 
 - [KubeVirt user-guide: Virtio Windows Driver disk usage](https://kubevirt.io/user-guide/virtual_machines/windows_virtio_drivers/)
-- [Creating a registry image with a VM disk](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/image-from-registry.md)
-- [CDI Upload User Guide](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/upload.md)
+- [Creating a registry image with a VM disk](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/image-from-registry.md)
+- [CDI Upload User Guide](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/upload.md)
 - [KubeVirt user-guide: How to obtain virtio drivers?](https://kubevirt.io/user-guide/virtual_machines/windows_virtio_drivers/#how-to-obtain-virtio-drivers)

--- a/_posts/2020-05-12-KubeVirt-VM-Image-Usage-Patterns.md
+++ b/_posts/2020-05-12-KubeVirt-VM-Image-Usage-Patterns.md
@@ -155,7 +155,7 @@ fedora-cloud-base   Bound    local-pv-e824538e   5Gi       RWO            local 
 
 While I’m not going to provide a detailed example here, another option for importing VM images into a PVC is to host the image on an http server (or as an s3 object) and then use a DataVolume to import the VM image into the PVC from a URL.
 
-Replace the url in this example with one hosting the qcow2 image. More information about this import method can be found [here](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/datavolumes.md#https3registry-source).
+Replace the url in this example with one hosting the qcow2 image. More information about this import method can be found [here](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#https3registry-source).
 
 ```sh
 kind: DataVolume
@@ -274,7 +274,7 @@ fedora-nginx            Bound    local-pv-8dla23ds    5Gi       RWO            l
 
 At this point we have a namespace, vm-images, that contains PVCs with our VM images on them. Those PVCs represent VM images in the same way AWS's AMIs represent VM images and this **vm-images namespace is our VM image repository.**
 
-Using CDI's i[cross namespace cloning feature](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/clone-datavolume.md#how-to-clone-an-image-from-one-dv-to-another-one), VM's can now be launched across multiple namespaces throughout the entire cluster using the PVCs in this “repository". Note that non-admin users need a special RBAC role to allow for this cross namespace PVC cloning. Any non-admin user who needs the ability to access the vm-images namespace for PVC cloning will need the RBAC permissions outlined [here](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/RBAC.md#pvc-cloning).
+Using CDI's i[cross namespace cloning feature](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/clone-datavolume.md#how-to-clone-an-image-from-one-dv-to-another-one), VM's can now be launched across multiple namespaces throughout the entire cluster using the PVCs in this “repository". Note that non-admin users need a special RBAC role to allow for this cross namespace PVC cloning. Any non-admin user who needs the ability to access the vm-images namespace for PVC cloning will need the RBAC permissions outlined [here](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/RBAC.md#pvc-cloning).
 
 Below is an example of the RBAC necessary to enable cross namespace cloning from the vm-images namespace to the default namespace using the default service account.
 

--- a/_posts/2020-12-10-Customizing-images-for-containerized-vms.md
+++ b/_posts/2020-12-10-Customizing-images-for-containerized-vms.md
@@ -485,7 +485,7 @@ Format specific information:
 ```
 
 > warning "Warning"
-> Virtual size of the image is 4.3G, since we agreed 10G the disk must be resized and root filesystem expanded before being containerized. Currently, there is no way to specify disk capacity in containerDisk as it can be done with [emptyDisks](https://github.com/kubevirt/kubevirt/blob/master/docs/container-empty-disks.md#implementation). The size of the root filesystem and disk when running in KubeVirt is driven by the image.
+> Virtual size of the image is 4.3G, since we agreed 10G the disk must be resized and root filesystem expanded before being containerized. Currently, there is no way to specify disk capacity in containerDisk as it can be done with [emptyDisks](https://github.com/kubevirt/kubevirt/blob/main/docs/container-empty-disks.md#implementation). The size of the root filesystem and disk when running in KubeVirt is driven by the image.
 > It is recommended to save the QCOW2 images under /var/lib/libvirt/images/ so that qemu user have permissions to expand or resize them.
 
 ```sh

--- a/_posts/2020-12-10-Monitoring-KubeVirt-VMs-from-the-inside.md
+++ b/_posts/2020-12-10-Monitoring-KubeVirt-VMs-from-the-inside.md
@@ -106,7 +106,7 @@ kubectl rollout status -n cdi deployment cdi-deployment
 
 Alright, cool. We have everything we need now. Let's setup the VM.
 
-We will start with the `PersistenVolume`'s required by [CDI’s DataVolume](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/datavolumes.md) resources. Since I’m using minikube with no dynamic storage provider, I’ll be creating 2 PVs with a reference to the PVCs that will claim them. Notice `claimRef` in each of the PVs.
+We will start with the `PersistenVolume`'s required by [CDI’s DataVolume](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md) resources. Since I’m using minikube with no dynamic storage provider, I’ll be creating 2 PVs with a reference to the PVCs that will claim them. Notice `claimRef` in each of the PVs.
 
 ```yaml
 apiVersion: v1

--- a/_posts/releases/2017-11-07-Kube-Virt-v004.markdown
+++ b/_posts/releases/2017-11-07-Kube-Virt-v004.markdown
@@ -88,5 +88,5 @@ Pre-built containers are published on Docker Hub and can be viewed at:
 
 \[git-evtag\]: <https://github.com/cgwalters/git-evtag#using-git-evtag>
 \[contributing\]:
-<https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md>
-\[license\]: <https://github.com/kubevirt/kubevirt/blob/master/LICENSE>
+<https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md>
+\[license\]: <https://github.com/kubevirt/kubevirt/blob/main/LICENSE>

--- a/_posts/releases/2017-12-08-Kube-Virt-v010.markdown
+++ b/_posts/releases/2017-12-08-Kube-Virt-v010.markdown
@@ -80,5 +80,5 @@ Pre-built containers are published on Docker Hub and can be viewed at:
 
 \[git-evtag\]: <https://github.com/cgwalters/git-evtag#using-git-evtag>
 \[contributing\]:
-<https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md>
-\[license\]: <https://github.com/kubevirt/kubevirt/blob/master/LICENSE>
+<https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md>
+\[license\]: <https://github.com/kubevirt/kubevirt/blob/main/LICENSE>

--- a/_posts/releases/2018-01-05-Kube-Virt-v020.markdown
+++ b/_posts/releases/2018-01-05-Kube-Virt-v020.markdown
@@ -68,5 +68,5 @@ Pre-built containers are published on Docker Hub and can be viewed at:
 
 \[git-evtag\]: <https://github.com/cgwalters/git-evtag#using-git-evtag>
 \[contributing\]:
-<https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md>
-\[license\]: <https://github.com/kubevirt/kubevirt/blob/master/LICENSE>
+<https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md>
+\[license\]: <https://github.com/kubevirt/kubevirt/blob/main/LICENSE>


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>


**What this PR does / why we need it**:

This removes references to KubeVirt `master` branches on repositories that have switched to use `main`. There a handful of repositories that haven't made the switch yet, so they were not able to be updated. This list includes:

- kubevirt-ansible
- vm-import-operator
- cloud-image-builder
- community
- ansible-kubevirt-modules
- common-templates
- kubevirt-tutorial

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

Begin to address #726 (but not finished)

**Special notes for your reviewer**:
