### PR TITLE
Moved multi-node section in minikube quickstart.

### DIFF
--- a/_includes/quickstarts/multi_node_minikube.md
+++ b/_includes/quickstarts/multi_node_minikube.md
@@ -1,10 +1,10 @@
-## Multi-Node Minikube
+### Multi-Node Minikube
 
 Minikube has support for adding additional nodes to a cluster. This can be
 helpful in experimenting with KubeVirt on minikube as some operations like node
 affinity or live migration require more than one cluster node to demonstrate.
 
-### Container Network Interface
+#### Container Network Interface
 
 By default, minikube sets up a kubernetes cluster using either a virtual
 machine appliance or a container. For a single node setup, local network
@@ -15,7 +15,7 @@ host. To this end, minikube supports a number of [Container Network Interface
 (CNI) plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)
 the simplest of which is [flannel](https://github.com/flannel-io/flannel#flannel).
 
-### Updating the minikube start command
+#### Updating the minikube start command
 
 To have minikube start up with the flannel CNI plugin over two nodes, alter the minikube start command:
 

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -52,6 +52,16 @@ Minikube ships a kubectl client version that matches the kubernetes version to a
   > info ""
   > See the minikube handbook [_here_](https://minikube.sigs.k8s.io/docs/) for advanced start options and instructions on how to operate minikube.
 
+{% include quickstarts/multi_node_minikube.md %}
+
+> warning "Core DNS race condition"
+> An issue has been
+> [reported](https://github.com/kubernetes/minikube/issues/11608) where the
+> `coredns` pod in multi-node minikube comes up with the wrong IP address. If
+> this happens, kubevirt will fail to install properly. To work around, delete
+> the `coredns` pod from the kube-system namespace and disable/enable the
+> kubevirt addon in minikube.
+
 ## Deploy KubeVirt
 
 KubeVirt can be installed using the KubeVirt operator, which manages the lifecycle of all the KubeVirt core components.
@@ -111,16 +121,6 @@ By default KubeVirt will deploy 7 pods, 3 services, 1 daemonset, 3 deployment ap
   ```bash
   kubectl logs pod/kubevirt-install-manager -n kube-system
   ```
-
-{% include quickstarts/multi_node_minikube.md %}
-
-> warning "Core DNS race condition"
-> An issue has been
-> [reported](https://github.com/kubernetes/minikube/issues/11608) where the
-> `coredns` pod in multi-node minikube comes up with the wrong IP address. If
-> this happens, kubevirt will fail to install properly. To work around, delete
-> the `coredns` pod from the kube-system namespace and disable/enable the
-> kubevirt addon in minikube.
 
 {% include quickstarts/virtctl.md %}
 


### PR DESCRIPTION
Multi-node section was identified in issue #759 as being in the wrong
place. Now all minikube specific modifications are grouped with
minikube.

Signed-off-by: cwilkers <cwilkers@redhat.com>

Fixes #759