### PR TITLE
Fixed #817, Moving Netlify configuration to local toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,11 @@ build_img: | envvar
 ## Check external, internal links and links/selectors to userguide on website content
 check_links: | envvar stop
 	@echo -n "${GREEN}Makefile: Check external and internal links${RESET}"
-	${DEBUG}${CONTAINER_ENGINE} run -it --rm --name website --net=host -v ${PWD}:/srv/:ro${SELINUX_ENABLED} -v /dev/null:/srv/Gemfile.lock --mount type=tmpfs,destination=/srv/_site --mount type=tmpfs,destination=/srv/.jekyll-cache ${IMGTAG} /bin/bash -c 'cd /srv; rake -- -u'
-	@echo
-	@echo
+	${DEBUG}${CONTAINER_ENGINE} run -it --rm --name website --net=host -v ${PWD}:/srv/:ro${SELINUX_ENABLED} -v /dev/null:/srv/Gemfile.lock --mount type=tmpfs,destination=/srv/_site --mount type=tmpfs,destination=/srv/.jekyll-cache ${IMGTAG} /bin/bash -c 'cd /srv; rake links:test_external; rake links:test_internal;'
+
+
+## Check links/selectors to userguide on website content
+check_links_selectors:
 	@echo "${GREEN}Makefile: Check url selectors to user-guide${RESET}"
 #BEGIN BIG SHELL SCRIPT
 	${DEBUG}${CONTAINER_ENGINE} run -it --rm --name website --net=host -v ${PWD}:/srv:ro${SELINUX_ENABLED} -v /dev/null:/srv/Gemfile.lock --mount type=tmpfs,destination=/srv/_site --mount type=tmpfs,destination=/srv/.jekyll-cache ${IMGTAG} /bin/bash -c 'cd /srv; rake --trace links:userguide_selectors' | sed -n -e '/HTML-Proofer finished successfully./,$$p' | grep -v 'HTML-Proofer finished successfully.' > links 2> /dev/null; \

--- a/Rakefile
+++ b/Rakefile
@@ -145,4 +145,4 @@ namespace :links do
 end
 
 desc 'The default task will execute all tests in a row'
-task :default => ['links:build', 'links:test_external', 'links:test_internal']
+task :default => ['links:build']

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "./_site"
+  command = "sed -i 's/jekyll build/jekyll build --future/g' Rakefile; rake; touch _site/.nojekyll"


### PR DESCRIPTION
**What this PR does / why we need it**:
* Created netlify.toml so that Netlify build config can be controlled via file in git
* Removed 'links:test_external', 'links:test_internal' from Rakefile so that duplicate link checking no longer occurs
* It appears check_selectors is broken again.  Moved the whole script to it's own Makefile target so it doesn't interfere with normal link checking.

> Fixes #817 
