### PR TITLE
Replaced old master branch name

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -9,7 +9,7 @@ Please use the following as general guidelines on any kind of contents generated
 ### Technical setup
 
 - Install `pre-commit` in your system and from the repositry folder run `pre-commit install` so that git hook is in place.
-  - It will avoid commits to `source` and `master` branch
+  - It will avoid commits to `source` and `main` branch
   - It will spell check articles before commit can be performed
   - Adjust some formatting in markdown like tables, spaces before and after headings, etc (via prettifier)
   - If you're using `npm` you can also add pre-commit as dependency for development so that it incorporates the `pre-commit` hook and it also spellchecks before you submit to CI and risk to get a failure in build. To do so, use: `npm install --save-dev pre-commit`

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ build_img: | envvar
 	@echo "${GREEN}Makefile: Building Image ${RESET}"
 	${DEBUG}if [ ! -e "./Dockerfile" ]; then \
 	  IMAGE="`echo $${IMGTAG} | sed -e s#\'##g -e s#localhost\/## -e s#:latest##`";  \
-	  if [ "`curl https://raw.githubusercontent.com/kubevirt/project-infra/master/images/kubevirt-kubevirt.github.io/Dockerfile -o ./Dockerfile -w '%{http_code}\n' -s`" != "200" ]; then \
+	  if [ "`curl https://raw.githubusercontent.com/kubevirt/project-infra/main/images/kubevirt-kubevirt.github.io/Dockerfile -o ./Dockerfile -w '%{http_code}\n' -s`" != "200" ]; then \
 	    echo "curl Dockerfile failed... exitting!"; \
 	    exit 2; \
 	  else \
@@ -126,7 +126,7 @@ build_img: | envvar
 	else \
 	  IMAGE="`echo $${TAG} | sed -e s#\'##g -e s#localhost\/## -e s#:latest##`"; \
 	  echo "DOCKERFILE file: ./Dockerfile"; \
-	  echo "Be sure to add changes to upstream: kubevirt/project-infra/master/images/${IMGTAG}/Dockerfile"; \
+	  echo "Be sure to add changes to upstream: kubevirt/project-infra/main/images/${IMGTAG}/Dockerfile"; \
 	  echo; \
 	fi; \
 	${CONTAINER_ENGINE} rmi ${IMGTAG} 2> /dev/null || echo -n; \
@@ -171,8 +171,8 @@ check_lint: | envvar stop
 check_spelling: | envvar stop
 	@echo "${GREEN}Makefile: Check spelling on site content${RESET}"
 	${DEBUG}if [ ! -e "./yaspeller.json" ]; then \
-		echo "${WHITE}Downloading Dictionary file: https://raw.githubusercontent.com/kubevirt/project-infra/master/images/yaspeller/.yaspeller.json${RESET}"; \
-		if ! `curl -fs https://raw.githubusercontent.com/kubevirt/project-infra/master/images/yaspeller/.yaspeller.json -o yaspeller.json`; then \
+		echo "${WHITE}Downloading Dictionary file: https://raw.githubusercontent.com/kubevirt/project-infra/main/images/yaspeller/.yaspeller.json${RESET}"; \
+		if ! `curl -fs https://raw.githubusercontent.com/kubevirt/project-infra/main/images/yaspeller/.yaspeller.json -o yaspeller.json`; then \
 			echo "${RED}ERROR: Unable to curl yaspeller dictionary file${RESET}"; \
 			exit 2; \
 		else \
@@ -182,7 +182,7 @@ check_spelling: | envvar stop
 		fi; \
 	else \
 		echo "YASPELLER file: ./yaspeller.json"; \
-		echo "Be sure to add changes to upstream: kubevirt/project-infra/master/images/yaspeller/.yaspeller.json"; \
+		echo "Be sure to add changes to upstream: kubevirt/project-infra/main/images/yaspeller/.yaspeller.json"; \
 		echo; \
 	fi; \
 	export IFS=$$'\n'; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contributing to KubeVirt.io
 
-[![Build Status](https://prow.ci.kubevirt.io/badge.svg?jobs=push-kubevirt.github.io-master-build-and-push-to-gh-pages)](https://prow.ci.kubevirt.io/?repo=kubevirt%2Fkubevirt.github.io&type=postsubmit&job=push-kubevirt.github.io-master-build-and-push-to-gh-pages)
+[![Build Status](https://prow.ci.kubevirt.io/badge.svg?jobs=push-kubevirt.github.io-main-build-and-push-to-gh-pages)](https://prow.ci.kubevirt.io/?repo=kubevirt%2Fkubevirt.github.io&type=postsubmit&job=push-kubevirt.github.io-main-build-and-push-to-gh-pages)
 
 The [kubevirt.io](https://kubevirt.io) website is a [Jekyll](https://jekyllrb.com/) driven site hosted by GitHub Pages.
 
@@ -51,27 +51,27 @@ upstream	git@github.com:kubevirt/kubevirt.github.io.git (fetch)
 upstream	git@github.com:kubevirt/kubevirt.github.io.git (push)
 ```
 
-To sync the master branch from the upstream repository, perform the following ...
+To sync the main branch from the upstream repository, perform the following ...
 
 ```bash
-git checkout master; git fetch upstream; git reset --hard upstream/master; git push origin master -f
+git checkout main; git fetch upstream; git reset --hard upstream/main; git push origin main -f
 ```
 
-*Note* Master branch is purely cosmetic for this repo. Merges to master **ARE NOT ACCEPTED**.
+*Note* Master branch is purely cosmetic for this repo. Merges to main **ARE NOT ACCEPTED**.
 
 
-All work must be branched from `master` branch. Perform the following to sync from upstream ...
+All work must be branched from `main` branch. Perform the following to sync from upstream ...
 
 ```bash
-git checkout master; git fetch upstream; git reset --hard upstream/master; git push origin master -f
+git checkout main; git fetch upstream; git reset --hard upstream/main; git push origin main -f
 ```
 
 #### Feature branch
 
-Even though changes from a local `master` branch are accepted it is inadvisable, can cause confusion and possibly data loss. Please use feature branches branched from `master` by running the following ...
+Even though changes from a local `main` branch are accepted it is inadvisable, can cause confusion and possibly data loss. Please use feature branches branched from `main` by running the following ...
 
 ```bash
-git checkout master; git fetch upstream; git reset --hard upstream/master; git push origin master -f; git branch feat_branch; git checkout feat_branch; git push --set-upstream origin feat_branch
+git checkout main; git fetch upstream; git reset --hard upstream/main; git push origin main -f; git branch feat_branch; git checkout feat_branch; git push --set-upstream origin feat_branch
 ```
 
 #### Rebase
@@ -79,7 +79,7 @@ git checkout master; git fetch upstream; git reset --hard upstream/master; git p
 Periodically a feature branch will need to be rebased as the local and origin fall behind upstream. Perform the following to rebase ...
 
 ```bash
-git checkout master; git fetch upstream; git reset --hard upstream/master; git push origin master -f; git checkout feat_branch; git rebase origin/master; git push -f
+git checkout main; git fetch upstream; git reset --hard upstream/main; git push origin main -f; git checkout feat_branch; git rebase origin/main; git push -f
 ```
 
 There is always a strong possibility for merge conflicts. Proceed with caution in resolving. Each conflict must be hand edited. Perform the following to resolve each conflict ...
@@ -172,7 +172,7 @@ git commit -s -m "The commit message" file1 file 2 file3 ...
 You will see the following in the transaction log
 ```bash
 git log
-commit hashbrowns (HEAD -> feat_branch, upstream/master, origin/master, master)
+commit hashbrowns (HEAD -> feat_branch, upstream/main, origin/main, main)
 Author: KubeVirt contributer <kubevirt_contributer@kubevirt.io>
 Date:   Mon Jan 01 00:00:00 2021 -0700
 
@@ -185,7 +185,7 @@ Signed-off-by: <your configured git identity>
 
 3) Often you will see a `Compare & Pull Request` button ... Click on that
 
-4) Ensure your base branch is `master`, your compare branch is `feat_branch`, and the file diff's are correct.
+4) Ensure your base branch is `main`, your compare branch is `feat_branch`, and the file diff's are correct.
 
 5) Create a nice subject and body for the pull request. Be sure to tag related issues, people of interest, and click the "Create pull request" button.
 

--- a/_includes/quickstarts/kubectl.md
+++ b/_includes/quickstarts/kubectl.md
@@ -1,3 +1,3 @@
-* A kubectl client is necessary for operating a Kubernetes cluster. It is important to install a  kubectl client version that matches the kubernetes version to avoid issues regarding <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew"><em>skew</em></a>.
+* A kubectl client is necessary for operating a Kubernetes cluster. It is important to install a  kubectl client version that matches the kubernetes version to avoid issues regarding <a href="https://github.com/kubernetes/community/blob/main/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew"><em>skew</em></a>.
 <br><br>
 To install kubectl client please follow the official documentation for your system using the instructions located <a href="https://kubernetes.io/docs/tasks/tools/install-kubectl/"><em>here</em></a>.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "publish-travis": "master _site",
+    "publish-travis": "main _site",
     "test": "yaspeller-ci --only-errors --find-repeat-words --ignore-digits --ignore-urls ./**/*.md"
   },
   "pre-commit": [


### PR DESCRIPTION
Some instances of "master" we missed in the website docs and Makefile after renaming the default branch to main.

Signed-off-by: cwilkers <cwilkers@redhat.com>
