### PR TITLE
Adding post to link to and socialize the second kubevirt summit

### DIFF
--- a/_posts/2022-01-24-KubeVirt-Summit-2022.md
+++ b/_posts/2022-01-24-KubeVirt-Summit-2022.md
@@ -1,0 +1,41 @@
+---
+layout: post
+author: Chandler Wilkerson
+description: Join us for the KubeVirt community's second annual dedicated online event
+navbar_active: Blogs
+category: news
+tags:
+  [
+    "kubevirt",
+    "event",
+    "community",
+  ]
+comments: true
+title: KubeVirt Summit is coming back!
+pub-date: Jan 24
+pub-year: 2022
+---
+
+The second online [KubeVirt Summit](/summit/) is coming on February 16, 2022!
+
+## When
+
+The event will take place online during two half-days:
+
+- Dates: February 16 and 17, 2022.
+- Time: 14:00 – 19:00 UTC (9:00–14:00 EST, 15:00–20:00 CET)
+
+## Register
+
+[KubeVirt Summit](/summit/) is hosted on Community.CNCF.io. Because of how that platform works, you need to register for each of the two days of the summit independantly:
+
+- [Register for Day 1](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-1/)
+- [Register for Day 2](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-2/)
+
+You will need to create an account with CNCF.io if you have not before. Attendance is free.
+
+## Keep up to date
+
+Connect with the KubeVirt Community through our [community page](/community).
+
+We are looking forward to meeting you there!


### PR DESCRIPTION
Creates blog post to ensure summit is in our news feed.

refers to https://github.com/kubevirt/kubevirt.github.io/pull/824

Signed-off-by: cwilkers <cwilkers@redhat.com>
