### PR TITLE
Add go import config for Node Maintenance Operator

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,7 @@
     <meta name="go-import" content="kubevirt.io/cpu-nfd-plugin git https://github.com/kubevirt/cpu-nfd-plugin">
     <meta name="go-import" content="kubevirt.io/containerized-data-importer-api git https://github.com/kubevirt/containerized-data-importer-api">
     <meta name="go-import" content="kubevirt.io/api git https://github.com/kubevirt/api">
+    <meta name="go-import" content="kubevirt.io/node-maintenance-operator git https://github.com/kubevirt/node-maintenance-operator">
     <link rel="apple-touch-icon" sizes="72x72" href="{{ site.baseurl }}/assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/assets/favicon/favicon-16x16.png">

--- a/pages/node-maintenance-operator.md
+++ b/pages/node-maintenance-operator.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title:
+permalink: /node-maintenance-operator/
+---
+
+To fetch Node Maintenance Operator sources run `go get -d kubevirt.io/node-maintenance-operator`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add go import config for Node Maintenance Operator for enabling `go get kubevirt.io/node-maintenance-operator`
