### PR TITLE
Removing explicit GMT timezone set in the website calendar link so that it displays in local time

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ twitter_username: kubevirt
 github_username:  kubevirt
 irc: kubevirt@irc.freenode.net
 Mailinglist: https://groups.google.com/forum/#!forum/kubevirt-dev
-calendar: https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io&ctz=GMT
+calendar: https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io
 events: 18pc0jur01k8f2cccvn5j04j1g@group.calendar.google.com
 kubevirt_version: v0.15.0
 kubernetes_version: v1.10.0


### PR DESCRIPTION
Calendar link currently explicitly set to GMT in the website link. Removing this should mean the calendar is accurate for viewer timezone.
Previously it did mention that times were shown in GMT, but it was in tiny font at bottom of screen and very easy to miss. 

Signed-off-by: aburdenthehand <aburden@redhat.com>


**Special notes for your reviewer**:
Tested by changing local timezone and opening new link. Calendar showed expected meeting times as per local timezone. 