### PR TITLE
Remove mention of Katacoda from homepage and labs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,6 @@ namespace :links do
             :external_only      => true,
             :internal_domains   => ["https://instructor.labs.sysdeseng.com", "https://www.youtube.com"],
             :url_ignore         => [ /http(s)?:\/\/(kubevirt.io\/\/(user-guide)?(videos)?).*/,
-                                     /http(s)?:\/\/(www.)?katacoda.com.*/,
                                      /http(s)?:\/\/(metal.)equinix.com.*/ ],
             :url_swap           => {'https://kubevirt.io/' => '',},
             :http_status_ignore => [0, 400, 429, 999]

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -25,16 +25,6 @@
             </header>
             <div class="kv-card">
               <div class="kv-card-body">
-                <img src="./../assets/images/katacoda.svg" alt="Katacoda Logo">
-                <p class="kv-card-text">
-                  KubeVirt on katacoda
-                </p>
-              </div>
-                <a href="https://www.katacoda.com/kubevirt" class="btn kv-btn kv-btn-primary" aria-label="Try It button">Try
-                  katacoda!</a>
-            </div>
-            <div class="kv-card">
-              <div class="kv-card-body">
                 <img src="./../assets/images/minikube-logo.svg" width="60px" height="60px" alt="MiniKube Logo">
                 <p class="kv-card-text">
                   KubeVirt on MiniKube

--- a/labs/kubernetes/lab1.md
+++ b/labs/kubernetes/lab1.md
@@ -19,8 +19,6 @@ tags:
 
 # Use KubeVirt
 
-You can experiment this lab online at [![Katacoda](/assets/images/katacoda-logo.png)](https://katacoda.com/kubevirt/scenarios/kubevirt-101)
-
 ### Create a Virtual Machine
 
 Download the VM manifest and explore it. Note it uses a [container disk](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk) and as such doesn't persist data. Such container disks currently exist for alpine, cirros and fedora.

--- a/labs/kubernetes/lab2.md
+++ b/labs/kubernetes/lab2.md
@@ -10,8 +10,6 @@ tags: [laboratory, importer, vm import, containerized data importer, CDI, lab]
 
 # Experiment with the Containerized Data Importer (CDI)
 
-You can experiment this lab online at [![Katacoda](/assets/images/katacoda-logo.png)](https://katacoda.com/kubevirt/scenarios/kubevirt-cdi)
-
 [CDI](https://github.com/kubevirt/containerized-data-importer) is a utility designed to import Virtual Machine images for use with Kubevirt.
 
 At a high level, a PersistentVolumeClaim (PVC) is created. A custom controller watches for importer specific claims, and when discovered, starts an import process to create a raw image named _disk.img_ with the desired content into the associated PVC.

--- a/labs/kubernetes/lab3.md
+++ b/labs/kubernetes/lab3.md
@@ -10,8 +10,6 @@ tags: [laboratory, kubevirt upgrades, upgrade, lifecycle, lab]
 
 # Experiment with KubeVirt Upgrades
 
-You can experiment this lab online at [![Katacoda](/assets/images/katacoda-logo.png)](https://katacoda.com/kubevirt/scenarios/kubevirt-upgrades)
-
 #### Deploy KubeVirt
 
 **_NOTE_**: For upgrading to the latest KubeVirt version, first we will install a specific older version of the operator, if you're already using latest, please start with an older KubeVirt version and follow [Lab1]({{ site.baseurl }}/labs/kubernetes/lab1) to deploy KubeVirt on it, but using version `v0.20.1` instead.


### PR DESCRIPTION
Signed-off-by: cwilkers <cwilkers@redhat.com>

**What this PR does / why we need it**:

Per #854 Katacoda is now a 404, so we need to remove and migrate. This PR just does the remove.

**Special notes for your reviewer**:
