### PR TITLE
Fix getting the latest CDI version in lab2

### DIFF
--- a/_includes/scriptlets/lab2/03_deploy_cdi_operator.sh
+++ b/_includes/scriptlets/lab2/03_deploy_cdi_operator.sh
@@ -1,2 +1,2 @@
-export VERSION=$(curl -sI https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+export VERSION=$(basename $(curl -s -w %{redirect_url} https://github.com/kubevirt/containerized-data-importer/releases/latest))
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml

--- a/_includes/scriptlets/lab2/03_deploy_cdi_operator.sh
+++ b/_includes/scriptlets/lab2/03_deploy_cdi_operator.sh
@@ -1,2 +1,2 @@
-export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+export VERSION=$(curl -sI https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
While doing the KubeVirt Labs I noticed that `VERSION` was not set using the snippet to install the CDI. Github is responding with a HTTP redirect, so the latest version needs to be grabbed from the location header instead of the response body.
