### PR TITLE
Replacing obsolete calendar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Targets:
 ## Developer
 
 * Github project: https://github.com/kubevirt
-* Community meetings: [Google Calendar](https://calendar.google.com/calendar/embed?src=18pc0jur01k8f2cccvn5j04j1g%40group.calendar.google.com&ctz=Etc%2FGMT)
+* Community meetings: [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io)
 
 ## Privacy
 


### PR DESCRIPTION
Signed-off-by: Andrew Burden <aburden@redhat.com>

**What this PR does / why we need it**:
There were some instances of old calendar links. Replacing these with the KubeVirt one. 
Follow up from https://github.com/kubevirt/community/pull/199

I see in `_config.yml` that there's an 'event' variable set, which also uses the old ID. I can't seem to find that used anywhere though.