### PR TITLE
Replacing google site verification tag with one associated with KubeVirt account

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
     <link rel="mask-icon" href="{{ site.baseurl }}/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
-    <meta name="google-site-verification" content="eaETLLM6xObn1li9l9eU8lNIBgBpU0OQLXV1faU1svE" />
+    <meta name="google-site-verification" content="ljFssJAOE7EegX8RSNhm2heZib4B2JPUwzoDLnIo0VM" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
Updating the site verification code so that it belongs to the cncf kubevirt account. 
@iranzo @dhiller @cwilkers - tagging you in case there are assets that I'm not aware of that currently rely on this, or any other reason why this should not be changed. Thanks!

Signed-off-by: Andrew Burden <aburden@redhat.com>
