### PR TITLE
Updating summit.md for KubeVirt Summit 2023

### DIFF
--- a/pages/summit.md
+++ b/pages/summit.md
@@ -5,56 +5,32 @@ permalink: /summit/
 order: 10
 ---
 
-The second online KubeVirt Summit is coming on Feburary 16-17!
+The third online KubeVirt Summit is coming on March 29-30!
 
 The KubeVirt Summit is a 2-day virtual event to discover,
 discuss, hack and learn about managing virtual machines in Kubernetes using
 KubeVirt.
 
-## When
+This is an opportunity for us to share what we're working on and to promote ideas 
+and discussion within the community in real-time. Whatever you're working on,
+however you're using KubeVirt, no matter how esoteric, we'd like to hear
+from you.
 
-The event will take place online during two half-days (5 hours each day):
+## Submit your proposal
 
-- Dates: February 16 and 17, 2022
-- Time: 14:00 – 19:00 UTC (09:00–14:00 EST, 15:00–20:00 CET)
+[CfP is open!](https://forms.gle/jsctRwyGR4MUcXst6) 
 
-## Register
+Session types include: Presentations (1-2 presenters), Discussions,
+Birds of a Feather (BoF), Panels (3-5 presenters), and Tutorials
+	
+## Important dates
 
-KubeVirt Summit is hosted on Community.CNCF.io.  Because of how that platform works, you need to register for each of the two days of the summit independantly:
+* CfP opens: January 12, 2023
+* CfP closes: February 2, 2023
+* Sessions chosen and speakers notified: February 10, 2023
+* Summit: March 29-30, 2023
 
-- [Register for Day 1](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-1/)
-- [Register for Day 2](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-2/)
+## Event page
 
-You will need to create an account with CNCF.io if you have not before. Attendance is free.
-
-## Schedule
-
-## [DAY 1](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-1/) Wednesday, February 16
-
-| Time (UTC) | Time (EST) | Session | Speaker | Track |
-| ------- | ------- | ----------------------------- | ------- | ------ |
-| 14:00 | 9:00 | Keynote/Intro | Fabian Deutch | General |
-| 14:25 | 9:25 | "KubeVirt on Arm64 (Progress, Troubles and Plans)" | Howard Zhang | Contributors |
-| 15:00 | 10:00 | EdgeStack and Singulus: Complete VM network implementation with KubeVirt CNI  | Sangho Shin, Jian Li | Users |
-| 15:30 | 10:30 | Live Migration Policies - fine tuning migrations dynamically (50min) | Itamar Holder | Users |
-| 16:35 | 11:35 | KubeVirt+Harverster: a Windows user tale | Nuno do Carmo | Users |
-| 17:10 | 12:10 | Kubernetes clusters on KubeVirt VMs | David Vossel, Alex Gradouski, Cheng Cheng | Users |
-| 17:45 | 12:45 | Network interface hotplug for KubeVirt | Miguel Duarte Barroso | Contributors |
-| 18:20 | 13:20 | A few bugs and findings from VMI Churn at NVIDIA | Fan Zhang | Contributors |
-
-## [DAY 2](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2022-day-2/) Thursday, February 17
-
-| Time (UTC) | Time (EST) | Session | Speaker | Track |
-| ------- | ------- | ----------------------------- | ------- | ------ |
-| 14:00 | 9:00 | KubeVirt Scale and Performance with SIG-Scale | Ryan Hallisey, Marcelo Amaral | Users |
-| 14:35 | 9:35 | Benchmarking the performance of CPU pinning using different virtual CPU topologies: a KVM vs. KubeVirt analysis | Guoqing Li, Marcelo Amaral | Contributors |
-| 15:10 | 10:10 | Delivering High-Performance VNF Workloads in KubeVirt: Navigating Network Acceleration for Low Latency Requirements | Pooja Ghumre, Ashutosh Tiwari  | Contributors |
-| 15:45 | 10:45 | Extending Kube-Burner to Support CRDs KubeVirt: An Open Source Benchmark Suite for Kubernetes Control Plane Analysis | Marcelo Amaral | Contributors |
-| 16:20 | 11:20 | Automatic configuration of mediated devices / vGPUs in KubeVirt | Vladik Romanovsky | Users
-| 16:55 | 11:55 | Volume Populator Support | Michael Henriksen | Users |
-| 17:30 | 12:30 | KubeVirt Performance Visualization at Nvidia | Qian Xiao | Users |
-| 18:05 | 13:05 | Closing Session | Fabian Deutch | General |
-
-## Sponsors
-
-The KubeVirt Summit is sponsored by the [CNCF](https://cncf.io/)
+The [KubeVirt Summit 2023 event page](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2023/)
+is live and will be updated with more information in February once the schedule has been announced.


### PR DESCRIPTION
Signed-off-by: Andrew Burden <aburden@redhat.com>


**What this PR does / why we need it**:
Updating summit.md with details for KubeVirt Summit 2023.
CfP is open now until Feb 2, 2023

Will update this page again with schedule information when it is available


