### PR TITLE
summit 23 blog post for newsreel

### DIFF
--- a/_posts/2023-03-03-KubeVirt-Summit-2023.md
+++ b/_posts/2023-03-03-KubeVirt-Summit-2023.md
@@ -1,0 +1,45 @@
+---
+layout: post
+author: Andrew Burden
+description: Join us for the KubeVirt community's third annual dedicated online event
+navbar_active: Blogs
+category: news
+tags:
+  [
+    "kubevirt",
+    "event",
+    "community",
+  ]
+comments: true
+title: KubeVirt Summit 2023!
+pub-date: Mar 03
+pub-year: 2023
+---
+
+The third online [KubeVirt Summit](/summit/) starts March 29, 2023!
+
+## When
+
+The event will take place online over two half-days:
+
+- Dates: March 29 and 30, 2023.
+- Time: 14:00 – 19:00 UTC (9:00–14:00 EST, 15:00–20:00 CET)
+
+## Register
+
+[KubeVirt Summit](/summit/) is hosted on Community.CNCF.io. This is a free event but you need to register in order to attend.
+
+[Register for KubeVirt Summit 2023](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2023/)
+
+If this is your first time attending, you will need to create an account with CNCF.io.
+
+## Schedule
+
+The schedule is available on the [CNCF Community Events page](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2023/) where you register, as well as on the [KubeVirt Summit page](/summit/).
+
+## Keep up to date
+
+Connect with the KubeVirt Community through our [community page](/community).
+
+See you there!
+


### PR DESCRIPTION
Simple blogpost with the basic details and all relevant links for KubeVirt Summit 2023.
This will put some Summit info on kubevirt.io via the newsreel

@cwilkers 