### PR TITLE
Summit reschedule (swapping sessions)

### DIFF
--- a/pages/summit.md
+++ b/pages/summit.md
@@ -19,9 +19,13 @@ and discussion within the community in real-time.
 
 [Register for KubeVirt Summit 2023](https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2023/) on the CNCF Community events page. Attendance is free.
 
+**Update due to technical issues**
+Day 1 experienced some technical issues with the event page listed above. We are waiting to hear whether this will be resolved before Day 2 begins. If it is not, we will update the above event page with the new link.
+
 ## Schedule
 
-Both days are 14:00 - 19:00 UTC (10:00–15:00 EDT, 16:00–21:00 CEST)
+Both days were orginally scheduled for 14:00 - 19:00 UTC (10:00–15:00 EDT, 16:00–21:00 CEST).
+Due to technical issues Thursday will start will be 13:00 - 19:00 UTC.
 
 ### March 29
 
@@ -95,6 +99,23 @@ Want to develop in the cloud with your friends? We'll invite you to walk through
 
 
 ### March 30
+
+1300-1325: **Update on KubeVirt’s Road to V1**<br>
+Presented by Ryan Hallisey & Fabian Deutsch
+
+The KubeVirt community will soon create the 59th release for KubeVirt, so let’s talk about what it will take for the next release to be v1.0.0.  In this talk we’ll discuss the upcoming changes in the community to get ready for 1.0 and the timeline.
+
+
+13:30-13:55: **Moving the instance type API towards v1 and streamlining the VM creation process**<br>
+Presented by Lee Yarwood & Felix Matouschek
+
+This presentation introduces the current state of the Instance type API (currently v1alpha2) and discusses the future planned improvements as we move towards v1. It will also provide an insight into the latest development advances in KubeVirt aiming to streamline the virtual machine creation process.
+
+By introducing virtual machine instance types and preferences, KubeVirt gains abstractions for resource sizing, performance and OS support, which allow users to focus on the parameters relevant to their applications. To make instance types and preferences approachable, the command line tools of KubeVirt were extended to enable a user experience on a par with all major hyperscalers.
+
+Attendees of this talk will learn about KubeVirt's new instance types and preferences, how they considerably improve the user experience and how they reduce the maintenance effort of KubeVirt virtual machines.
+
+
 14:00-14:25: **The latest in KubeVirt VM exports**<br>
 Presented by Maya Rashish
 

--- a/pages/summit.md
+++ b/pages/summit.md
@@ -65,10 +65,10 @@ Presented by Marcelo Feitoza Parisi
 KubeVirt-Manager is an Open Source initiative that plans to democratize KubeVirt usage and scale KubeVirt's reach to legacy virtualization administrators and users, by delivering a simple, effective and friendly Web User Interface for KubeVirt, using technologies like AngularJS, Bootstrap and NoVNC embedded. By implementing a simple Web User Interface, KubeVirt-Manager can effectively eliminate the needs of writing and managing complex Kubernetes YAML files. Containerized Data Importer is also used by KubeVirt-Manager as a backend for Data Volume general management tasks, like provisioning, creating and scaling.
 
 
-16:30-16:55: **The latest in KubeVirt VM exports**<br>
-Presented by Maya Rashish
+16:30-16:55: **How Killercoda works with KubeVirt**<br>
+Presented by Meha Bhalodiya & Adam Gardner
 
-We'll talk about the recently introduced feature for easily exporting VMs and use some recent quality of life improvements that have made it in since the feature was introduced
+By using KubeVirt in conjunction with Killercoda, users can take advantage of the benefits of virtualization while still utilizing the benefits of Kubernetes. This can provide a powerful and flexible platform for running VMs, and can help to simplify the management of VMs and to improve the performance and security of the platform.  The integration of virtualization technology with Kubernetes allows customers to easily manage and monitor their VMs while taking advantage of the scalability and self-healing capabilities of Kubernetes. With Killercoda, users can create custom virtual networks, use firewalls and load balancers, and even establish VPN connections between VMs and other resources.
 
 
 17:00-17:50: **DPU Accelerated Networking for KubeVirt Pods**<br>
@@ -95,11 +95,10 @@ Want to develop in the cloud with your friends? We'll invite you to walk through
 
 
 ### March 30
+14:00-14:25: **The latest in KubeVirt VM exports**<br>
+Presented by Maya Rashish
 
-14:00-14:25: **How Killercoda works with KubeVirt**<br>
-Presented by Meha Bhalodiya & Adam Gardner
-
-By using KubeVirt in conjunction with Killercoda, users can take advantage of the benefits of virtualization while still utilizing the benefits of Kubernetes. This can provide a powerful and flexible platform for running VMs, and can help to simplify the management of VMs and to improve the performance and security of the platform.  The integration of virtualization technology with Kubernetes allows customers to easily manage and monitor their VMs while taking advantage of the scalability and self-healing capabilities of Kubernetes. With Killercoda, users can create custom virtual networks, use firewalls and load balancers, and even establish VPN connections between VMs and other resources.
+We'll talk about the recently introduced feature for easily exporting VMs and use some recent quality of life improvements that have made it in since the feature was introduced 
 
 
 14:30-14:55: **High Performance Network Stack for KubeVirt-based Managed Kubernetes**<br>


### PR DESCRIPTION
Swapping sessions between days to accommodate presenters. 

The summit webpage should now reflect the changes already made on the CNCF events page: https://community.cncf.io/events/details/cncf-kubevirt-community-presents-kubevirt-summit-2023/
