### PR TITLE
Fix localnet blog

### DIFF
--- a/_posts/2023-05-31-OVN-kubernetes-secondary-networks-localnet.md
+++ b/_posts/2023-05-31-OVN-kubernetes-secondary-networks-localnet.md
@@ -119,10 +119,10 @@ created.
 
 You will also have to configure an IP address on the bridge for the
 extra-network the kind script created. For that, you first need to identify the
-bridge's name:
+bridge's name. In the example below we're providing a command for the podman
+runtime:
 ```bash
-OCI_BIN=podman | docker # choose your cup of tea.
-$OCI_BIN network inspect underlay --format '{ .NetworkInterface }}'
+podman network inspect underlay --format '{{ .NetworkInterface }}'
 podman3
 
 ip addr add 10.128.0.1/24 dev podman3

--- a/_posts/2023-05-31-OVN-kubernetes-secondary-networks-localnet.md
+++ b/_posts/2023-05-31-OVN-kubernetes-secondary-networks-localnet.md
@@ -100,7 +100,7 @@ for node in $(kubectl -n ovn-kubernetes get pods -l app=ovs-node -o jsonpath="{.
 do
 	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl --may-exist add-br ovsbr1
 	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl --may-exist add-port ovsbr1 eth1
-	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl set open . external_ids:ovn-bridge-mappings=physnet:breth0,localnet.network_br-localnet:ovsbr1
+	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl set open . external_ids:ovn-bridge-mappings=physnet:breth0,localnet-network:ovsbr1
 done
 ```
 
@@ -112,6 +112,10 @@ It creates a patch port between the OVN integration bridge - `br-int` - and the
 OVS bridge you tell it to, and traffic will be forwarded to/from it with the
 help of a
 [localnet port](https://man7.org/linux/man-pages/man5/ovn-nb.5.html#Logical_Switch_Port_TABLE).
+
+**NOTE:** The provided mapping **must** match the `name` within the
+`net-attach-def`.Spec.Config JSON, otherwise, the patch ports will not be
+created.
 
 You will also have to configure an IP address on the bridge for the
 extra-network the kind script created. For that, you first need to identify the
@@ -328,7 +332,7 @@ for node in $(kubectl -n ovn-kubernetes get pods -l app=ovs-node -o jsonpath="{.
 do
 	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl --may-exist add-br ovsbr1
 	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl --may-exist add-port ovsbr1 eth1 trunks=10,20 vlan_mode=trunk
-	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl set open . external_ids:ovn-bridge-mappings=physnet:breth0,tenantblue_br-localnet:ovsbr1,tenantred_br-localnet:ovsbr1
+	kubectl -n ovn-kubernetes exec -ti $node -- ovs-vsctl set open . external_ids:ovn-bridge-mappings=physnet:breth0,tenantblue:ovsbr1,tenantred:ovsbr1
 done
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:
[This PR](https://github.com/ovn-org/ovn-kubernetes/pull/3609) reacts to changes in the ovn-kubernetes repo, where the `_br-localnet` suffix was removed from the mapping configuration.

Thus, we need to adjust the existing blog post, otherwise the provided instructions will not provide a working scenario.

We also clarify the existing command to retrieve the name of the bridge where the "gateway" IP must be set only works for podman.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
