### PR TITLE
Update CDI lab to match the current behavior

### DIFF
--- a/_includes/scriptlets/lab2/06_create_fedora_cloud_instance.sh
+++ b/_includes/scriptlets/lab2/06_create_fedora_cloud_instance.sh
@@ -1,18 +1,16 @@
-cat <<EOF > pvc_fedora.yml
-apiVersion: v1
-kind: PersistentVolumeClaim
+cat <<EOF > dv_fedora.yml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
 metadata:
   name: "fedora"
-  labels:
-    app: containerized-data-importer
-  annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.raw.xz"
 spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
+  storage:
+    resources:
+      requests:
+        storage: 5Gi
+  source:
+    http:
+      url: "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.raw.xz"
 EOF
 
-kubectl create -f pvc_fedora.yml
+kubectl create -f dv_fedora.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

The CDI lab in kubevirt.io contains out-of-date processes and information, to the point where it recommends the creation of a PVC with import annotations instead of a DataVolume. The given example simply doesn't work with the latest CDI version.

Though we plan to eventually change the way CDI works with DataVolumes (check https://github.com/kubevirt/containerized-data-importer/pull/2752 for more information), the lab should at least provide a working example so users can test CDI's latest versions.

With the adoption of populators this process will require an update again soon, but since users have been reporting issues with the current lab (https://github.com/kubevirt/containerized-data-importer/issues/2830 or https://github.com/kubevirt/containerized-data-importer/issues/2645#issuecomment-1489913173) at least we should fix it for the moment.




