### PR TITLE
Add propagateASGTags to code block

### DIFF
--- a/_posts/2023-09-06-KubeVirt-on-autoscaling-nodes.md
+++ b/_posts/2023-09-06-KubeVirt-on-autoscaling-nodes.md
@@ -194,6 +194,7 @@ managedNodeGroups:
     volumeIOPS: 10000
     volumeThroughput: 750
     volumeType: gp3
+    propagateASGTags: true
     tags:
       alpha.eksctl.io/nodegroup-name: ng-${EKS_AZ}-c5-metal
       alpha.eksctl.io/nodegroup-type: managed


### PR DESCRIPTION
This ensures that the tags we set in the node group is also copid over to the underlying autoscaling group which is what the cluster autoscaler will look at for determining which node group to scale up.

**What this PR does / why we need it**:

This adds a missing line in a code block.