### PR TITLE
Add go-import containerdisks

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,7 @@
     <meta name="go-import" content="kubevirt.io/containerized-data-importer-api git https://github.com/kubevirt/containerized-data-importer-api">
     <meta name="go-import" content="kubevirt.io/api git https://github.com/kubevirt/api">
     <meta name="go-import" content="kubevirt.io/node-maintenance-operator git https://github.com/kubevirt/node-maintenance-operator">
+    <meta name="go-import" content="kubevirt.io/containerdisks git https://github.com/kubevirt/containerdisks">
     <link rel="apple-touch-icon" sizes="72x72" href="{{ site.baseurl }}/assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/assets/favicon/favicon-16x16.png">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Add go-import to import containerdisks via kubevirt.io domain.
