### PR TITLE
Adding jed as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,7 @@ filters:
     reviewers:
       - aburdenthehand
       - cwilkers
-      - jobbler
+      - jean-edouard
     approvers:
       - aburdenthehand
       - cwilkers


### PR DESCRIPTION
My understanding is John is no longer involved with the project in any major way. As such I've removed him as a reviewer.
Jed (@jean-edouard) has kindly volunteered to become a reviewer for this repo.
Jed is an approver of kubevirt/kubevirt and has contributed 4 blogs.