### PR TITLE
Summit 2024 blog and page update for CfP

### DIFF
--- a/_posts/2024-03-19-KubeVirt-Summit-2024-CfP.md
+++ b/_posts/2024-03-19-KubeVirt-Summit-2024-CfP.md
@@ -1,11 +1,22 @@
 ---
-layout: page
-title: KubeVirt Summit 2024!
-permalink: /summit/
-order: 10
+layout: post
+author: Andrew Burden
+description: Join us for the KubeVirt community's fourth annual dedicated online event
+navbar_active: Blogs
+category: news
+tags:
+  [
+    "kubevirt",
+    "event",
+    "community",
+  ]
+comments: true
+title: KubeVirt Summit 2024 CfP is open!
+pub-date: Mar 19
+pub-year: 2024
 ---
 
-The fourth online KubeVirt Summit is coming on June 25-26!
+We are very pleased to announce the details for this year's KubeVirt Summit!! 
 
 ## What is KubeVirt Summit?
 


### PR DESCRIPTION
Announcing KubeVirt Summit 2024

This is a blog post and an update to the website Summit page. 
The copy is more or less the same. The Summit page will be updated at the end of May once we've closed the CfP, selected our speakers, and organised our schedule. 

Unfortunately the make build failed out so I was not able to look at a local build #935 