### PR TITLE
Adding Summit to the nav pages and a responsive banner

### DIFF
--- a/_data/site_nav_pages.yml
+++ b/_data/site_nav_pages.yml
@@ -1,4 +1,8 @@
 nav:
+  - title: Summit 24 CfP
+    page: Summit
+    url: /summit/
+
   - title: Blogs
     page: Blogs
     url: /blogs/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,9 @@
   <a class="navbar-brand" href="/">
     <img src="{{ site.baseurl }}/assets/images/KubeVirt_logo_color.svg" class="navbar-brand-image d-inline-block align-top" alt="KubeVirt.io">
   </a>
+  <div class="collapse navbar-nav navbar-collapse" style="padding-left: 400px; width: 300px; margin: 0 auto" data-toggle="collapse">
+         <h1><a style="color: white; font-size:1.5vw; font-weight: bold; white-space: nowrap;" href="https://kubevirt.io/summit/">KubeVirt Summit 2024: June 25-26</a></h1>
+  </div>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <i class="fas fa-th-large"></i>
   </button>


### PR DESCRIPTION
Adding Summit CfP and link to the nav buttons, and a responsive banner to the website which in local testing behaves well at any screen size. It's admittedly slightly redundant having both but the banner doesn't show in mobile, whereas the nav button will. 

After May 20 we will need to update the nav button title, and after Summit we can remove both.