### PR TITLE
Add go-import for kubevirt.io/vm-console-proxy project

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,7 @@
     <meta name="go-import" content="kubevirt.io/cloud-provider-kubevirt git https://github.com/kubevirt/cloud-provider-kubevirt">
     <meta name="go-import" content="kubevirt.io/controller-lifecycle-operator-sdk git https://github.com/kubevirt/controller-lifecycle-operator-sdk">
     <meta name="go-import" content="kubevirt.io/ssp-operator git https://github.com/kubevirt/ssp-operator">
+    <meta name="go-import" content="kubevirt.io/vm-console-proxy git https://github.com/kubevirt/vm-console-proxy">
     <meta name="go-import" content="kubevirt.io/cpu-nfd-plugin git https://github.com/kubevirt/cpu-nfd-plugin">
     <meta name="go-import" content="kubevirt.io/containerized-data-importer-api git https://github.com/kubevirt/containerized-data-importer-api">
     <meta name="go-import" content="kubevirt.io/application-aware-quota-api git https://github.com/kubevirt/application-aware-quota-api">


### PR DESCRIPTION
**What this PR does / why we need it**:
Added go module redirect for `kubevirt.io/vm-console-proxy` to be consistent with other kubevirt projects.
