### PR TITLE
Removing banner and nav page for kubevirt summit

### DIFF
--- a/_data/site_nav_pages.yml
+++ b/_data/site_nav_pages.yml
@@ -1,8 +1,4 @@
 nav:
-  - title: KubeVirt Summit 24
-    page: Summit
-    url: /summit/
-
   - title: Blogs
     page: Blogs
     url: /blogs/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,6 @@
   <a class="navbar-brand" href="/">
     <img src="{{ site.baseurl }}/assets/images/KubeVirt_logo_color.svg" class="navbar-brand-image d-inline-block align-top" alt="KubeVirt.io">
   </a>
-  <div class="collapse navbar-nav navbar-collapse" style="padding-left: 400px; width: 300px; margin: 0 auto" data-toggle="collapse">
-         <h1><a style="color: white; font-size:1.5vw; font-weight: bold; white-space: nowrap;" href="/summit/">KubeVirt Summit 2024: June 24-25</a></h1>
-  </div>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <i class="fas fa-th-large"></i>
   </button>


### PR DESCRIPTION
Rolling back #944 to remove the Summit banner in the header, and from the nav page.

