### PR TITLE
Fix shell's expansion of `VERSION` in deploy command

### DIFF
--- a/pages/quickstart_cloud.md
+++ b/pages/quickstart_cloud.md
@@ -45,7 +45,7 @@ KubeVirt can be installed using the KubeVirt operator, which manages the lifecyc
   ```bash
   export VERSION=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
   echo $VERSION
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml"
   ```
 
   > warning "Nested virtualization"

--- a/pages/quickstart_cloud.md
+++ b/pages/quickstart_cloud.md
@@ -59,7 +59,7 @@ KubeVirt can be installed using the KubeVirt operator, which manages the lifecyc
 * Again use `kubectl` to deploy the KubeVirt custom resource definitions:
 
   ```bash
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml"
   ```
 
 ### Verify components

--- a/pages/quickstart_kind.md
+++ b/pages/quickstart_kind.md
@@ -59,7 +59,7 @@ KubeVirt can be installed using the KubeVirt operator, which manages the lifecyc
 * Again use `kubectl` to deploy the KubeVirt custom resource definitions:
 
   ```bash
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml"
   ```
 
 ### Verify components

--- a/pages/quickstart_kind.md
+++ b/pages/quickstart_kind.md
@@ -45,7 +45,7 @@ KubeVirt can be installed using the KubeVirt operator, which manages the lifecyc
   export VERSION=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
 
   echo $VERSION
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml"
   ```
 
   > warning "Nested virtualization"

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -104,7 +104,7 @@ Below are two examples of how to install KubeVirt using the latest release.
 * Again use `kubectl` to deploy the KubeVirt custom resource definitions:
 
   ```bash
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-cr.yaml"
   ```
 
 ### Verify components

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -90,7 +90,7 @@ Below are two examples of how to install KubeVirt using the latest release.
   ```bash
   export VERSION=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
   echo $VERSION
-  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml
+  kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/kubevirt-operator.yaml"
   ```
 
 > warning "Nested virtualization"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

This PR fixes the improper interpolation of the "VERSION" variable within the URL string in the kubectl create command. This is because the curly braces {} are not being interpreted correctly in the URL as when they are pasted in other shells like `zsh`, escape is inserted around `{` & `}`.

To fix this, we need to use double quotes for the URL string in the kubectl create command.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #934


**Special notes for your reviewer**:
