### PR TITLE
Moving cwilkers to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,11 +3,9 @@ filters:
     reviewers:
       - aburdenthehand
       - brianmcarey
-      - cwilkers
       - jean-edouard
     approvers:
       - aburdenthehand
-      - cwilkers
       - fabiand
       - davidvossel
       - dhiller
@@ -15,6 +13,7 @@ filters:
       - phoracek
       - stu-gott
     emeritus_approvers:
+      - cwilkers # 03 Oct 2024
       - mazzystr # 20 Nov 2023
       - codificat # 09 June 2021
       - hroyrh # 09 June 2021


### PR DESCRIPTION
Moving @cwilkers  to emeritus as he is not longer active in the community, and it has been 6 months since his last contribution (I believe). 
I want to thank Chandler for his many contributions to this project, especially in this repo, in which he did an amazing job helping to maintain and ensure things ran smoothly.