### PR TITLE
New blog for the v1.4 release

### DIFF
--- a/_posts/2024-11-12-KubeVirt-v1-4.md
+++ b/_posts/2024-11-12-KubeVirt-v1-4.md
@@ -1,0 +1,60 @@
+---
+layout: post
+author: KubeVirt Maintainers
+title: You wanted more? It's KubeVirt v1.4! 
+description: Introducing the KubeVirt v1.4 release
+navbar_active: 
+pub-date: November 12
+pub-year: 2024
+category: news
+tags:
+  [
+    "KubeVirt",
+    "v1.4",
+    "release",
+    "community",
+    "cncf",
+    "milestone",
+    "party time"
+  ]
+
+---
+
+The KubeVirt Community is proud to announce the release of [v1.4](https://github.com/kubevirt/kubevirt/releases/tag/v1.4.0). This release aligns with [Kubernetes v1.31](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/) and is the sixth KubeVirt release to follow the Kubernetes release cadence. 
+
+What's 1/3 of one thousand? Because that's how many people have [contributed in some way](https://kubevirt.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=v1.3.0%20-%20now&var-metric=contributions&var-repogroup_name=All&var-country_name=All&var-companies=All) to this release, with 90 of those 333 people [contributing commits to our repos](https://kubevirt.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=v1.3.0%20-%20now&var-metric=commits&var-repogroup_name=All&var-country_name=All&var-companies=All). 
+
+You can read the full [release notes](https://kubevirt.io/user-guide/release_notes/#v140) in our user-guide, but we have included some highlights in this blog.
+
+### Feature GA
+This release marks the graduation of a number of features to GA; deprecating the feature gate and now enabled by default:
+
+- [Network hotplug](https://kubevirt.io/user-guide/network/hotplug_interfaces/#hotplug-network-interfaces): Add network interfaces to, and remove them from, running virtual machines.
+- [Common Instance types](https://kubevirt.io/user-guide/user_workloads/instancetypes/): Simplify virtual machine creation with a predefined set of resource, performance, and runtime settings. We have also introduced a single configurable for cluster admins to explicitly disable this feature if required.
+- [NUMA](https://deploy-preview-840--kubevirt-user-guide.netlify.app/compute/numa/): Improving performance by mapping host NUMA topology to virtual machine topology.
+- [GPU assignment](https://deploy-preview-840--kubevirt-user-guide.netlify.app/compute/host-devices/#host-devices-assignment): An oldie but a goodie: Assign GPUs and vGPUs to virtual machines.
+
+This version of KubeVirt includes upgraded virtualization technology based on [libvirt 10.5.0](https://www.libvirt.org/news.html#v10-5-0-2024-07-01) and [QEMU 9.0.0](https://www.qemu.org/2024/04/23/qemu-9-0-0/). Other KubeVirt-specific features of this release include the following:
+
+### Virtualization
+In the interest of security, we have restricted the [ability of virt-handler](https://github.com/kubevirt/kubevirt/pull/11982) to patch nodes, and removed privileges for the cluster. You can also now [live-update tolerations](https://github.com/kubevirt/kubevirt/pull/13090) to a running VM.
+
+Our KubeVirt command line tool, virtctl, also received some love and [improved functionality](https://kubevirt.io/user-guide/release_notes/ba#sig-compute) for VM creation, image upload, and source inference.
+
+### Networking
+The networking binding plugins have matured to Beta, and we have a new domain attachment type,[`managedTap`](https://github.com/kubevirt/kubevirt/pull/13024), and the ability to [reserve memory overhead](https://github.com/kubevirt/kubevirt/pull/12235) for the binding. [Network plugin bindings](https://kubevirt.io/user-guide/network/network_binding_plugins/) enable vendors to provide their own VM-to-network plumbing alongside KubeVirt.
+
+We introduced [Dynamic Primary Pod NIC Names](https://github.com/kubevirt/kubevirt/pull/13018), which supports different CNIs to leverage various interface names, and added support for the `igb` network interface model.
+
+### Storage
+If you've ever wanted to migrate your virtual machine volume from one storage type to another then you'll be interested in our [volume migration](https://kubevirt.io/user-guide/storage/volume_migration/) feature.
+
+And for those running Windows VMs, [backend-storage now supports RWO file systems](https://github.com/kubevirt/kubevirt/pull/12629). Backend-storage volumes are those created for persistent data to enable vTPM and UEFI for VMs.
+
+### Scale and Performance
+Our SIG scale and performance team have [integrated KWOK with SIG-scale tests](https://github.com/kubevirt/kubevirt/pull/12117) to simulate nodes and VMIs to test performance while using lower resource requirements.
+
+### Thanks!
+A lot of work from a huge amount of people go into these releases. Some contributions are small, such as raising a bug or attending our community meeting, and others are massive, like working on a feature or reviewing PRs. Whatever your part: we thank you. 
+
+And if you're interested in contributing to the project and being a part of the next release, please check out our [contributing guide](https://kubevirt.io/user-guide/contributing/) and our [community membership guidelines](https://github.com/kubevirt/community/blob/main/membership_policy.md).

--- a/_posts/2024-11-12-KubeVirt-v1-4.md
+++ b/_posts/2024-11-12-KubeVirt-v1-4.md
@@ -26,6 +26,8 @@ What's 1/3 of one thousand? Because that's how many people have [contributed in 
 
 You can read the full [release notes](https://kubevirt.io/user-guide/release_notes/#v140) in our user-guide, but we have included some highlights in this blog.
 
+For those of you at KubeCon this week, be sure to check out our [maintainer talk](https://sched.co/1hoy6) where our project maintainers will be going into these and other recent enhancements in KubeVirt. 
+
 ### Feature GA
 This release marks the graduation of a number of features to GA; deprecating the feature gate and now enabled by default:
 
@@ -42,17 +44,15 @@ In the interest of security, we have restricted the [ability of virt-handler](ht
 Our KubeVirt command line tool, virtctl, also received some love and [improved functionality](https://kubevirt.io/user-guide/release_notes/ba#sig-compute) for VM creation, image upload, and source inference.
 
 ### Networking
-The networking binding plugins have matured to Beta, and we have a new domain attachment type,[`managedTap`](https://github.com/kubevirt/kubevirt/pull/13024), and the ability to [reserve memory overhead](https://github.com/kubevirt/kubevirt/pull/12235) for the binding. [Network plugin bindings](https://kubevirt.io/user-guide/network/network_binding_plugins/) enable vendors to provide their own VM-to-network plumbing alongside KubeVirt.
+The networking binding plugins have matured to Beta, and we have a new domain attachment type,[`managedTap`](https://github.com/kubevirt/kubevirt/pull/13024), and the ability to [reserve memory overhead](https://github.com/kubevirt/kubevirt/pull/12235) for binding plugins. [Network binding plugins](https://kubevirt.io/user-guide/network/network_binding_plugins/) enable vendors to provide their own VM-to-network plumbing alongside KubeVirt.
 
-We introduced [Dynamic Primary Pod NIC Names](https://github.com/kubevirt/kubevirt/pull/13018), which supports different CNIs to leverage various interface names, and added support for the `igb` network interface model.
+We also added support for the `igb` network interface model.
 
 ### Storage
 If you've ever wanted to migrate your virtual machine volume from one storage type to another then you'll be interested in our [volume migration](https://kubevirt.io/user-guide/storage/volume_migration/) feature.
 
-And for those running Windows VMs, [backend-storage now supports RWO file systems](https://github.com/kubevirt/kubevirt/pull/12629). Backend-storage volumes are those created for persistent data to enable vTPM and UEFI for VMs.
-
 ### Scale and Performance
-Our SIG scale and performance team have [integrated KWOK with SIG-scale tests](https://github.com/kubevirt/kubevirt/pull/12117) to simulate nodes and VMIs to test performance while using lower resource requirements.
+Our SIG scale and performance team have added performance benchmarks for resource utilization of virt-controller and virt-api components. Furthermore, the test-suite was enhanced by [integrating KWOK with SIG-scale tests](https://github.com/kubevirt/kubevirt/pull/12117) to simulate nodes and VMIs to test KubeVirt performance while using minimum resources in test infrastructure. A comprehensive list of performance and scale benchmarks for the release is available [here](https://github.com/kubevirt/kubevirt/blob/main/docs/perf-scale-benchmarks.md).
 
 ### Thanks!
 A lot of work from a huge amount of people go into these releases. Some contributions are small, such as raising a bug or attending our community meeting, and others are massive, like working on a feature or reviewing PRs. Whatever your part: we thank you. 


### PR DESCRIPTION
Adding a blog for our v1.4 release to cover key changes and hype some of our awesome new features. 

To be published alongside the release on November 12
(There's also a [user-guide PR for the release notes](https://github.com/kubevirt/user-guide/pull/850/files))