### PR TITLE
Add Bluesky and Mastodon social links to website footer (#986)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,6 +30,14 @@
         <a href="https://www.youtube.com/channel/UC2FH36TbZizw25pVT1P3C3g/videos" data-toggle="tooltip" data-placement="top" title="Subscribe to our YouTube channel!" class="link-social-youtube">
           <i class="fab fa-youtube fa-lg"></i>
         </a>
+        
+        <a href="https://bsky.app/profile/kubevirt.bsky.social" data-toggle="tooltip" data-placement="top" title="Follow us on Bluesky!" class="link-social-bluesky">
+          <i class="fa-brands fa-bluesky fa-lg"></i>
+        </a>
+
+        <a href="https://fosstodon.org/@kubevirt" rel="me" data-toggle="tooltip" data-placement="top" title="Follow us on Mastodon!" class="link-social-mastodon">
+          <i class="fab fa-mastodon fa-lg"></i>
+        </a>
 
       </p>
     </div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -70,7 +70,8 @@
     <footer class="footer" role="contentinfo">
       {% include footer.html %}
     </footer>
-    <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js" integrity="sha384-3LK/3kTpDE/Pkp8gTNp2gR/2gOiwQ6QaO7Td0zV76UFJVhqLl4Vl3KL1We6q6wR9" crossorigin="anonymous"></script>
+    
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm" crossorigin="anonymous"></script>

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -9,7 +9,9 @@
       &-mail,
       &-calendar,
       &-slack,
-      &-youtube {
+      &-youtube,
+      &-bluesky,
+      &-mastodon {
         color: $kv-color--black-400;
         @media (max-width: 576px) {
           font-size: 2rem;
@@ -53,7 +55,24 @@
           color: #cc0000;
         }
       }
+
+      &-bluesky {
+        margin-right: 1rem;
+
+        &:hover {
+          color: #0A79FC;
+        }
+      }
+
+      &-mastodon {
+        margin-right: 1rem;
+
+        &:hover {
+          color: #5B4BE1;
+        }
+      }
     }
+
     &.privacy-statement {
       &-link {
         &:hover {
@@ -61,14 +80,17 @@
         }
       }
     }
+
     &:hover {
       text-decoration: none;
     }
   }
+
   &-licensing {
-    font-size: .8rem;
+    font-size: 0.8rem;
+
     a {
-        font-size: .8rem;
+      font-size: 0.8rem;
     }
   }
 }


### PR DESCRIPTION
This PR adds links to KubeVirt's Bluesky and Mastodon accounts in the website footer to improve discoverability and community engagement.

### Changes made:
- Added new `<a>` tags with icons for Bluesky and Mastodon in `_includes/footer.html`
- Updated Font Awesome from v5.1.0 to v6.5.2 in `_layouts/homepage.html` to support `fa-bluesky` 
- Added styling for the new social links in `_sass/_footer.scss`

### Social links:
- Bluesky: https://bsky.app/profile/kubevirt.bsky.social
- Mastodon: https://fosstodon.org/@kubevirt

Fixes: #986
![image](https://github.com/user-attachments/assets/dc1eaf50-b580-45b2-b9c4-fba2cbd3704f)
![image](https://github.com/user-attachments/assets/c315941f-dcc0-42f9-8b03-08bd7a3698ef)
