### PR TITLE
feat: Add go-import meta tags for virt-template

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,9 @@
     <meta name="go-import" content="kubevirt.io/api git https://github.com/kubevirt/api">
     <meta name="go-import" content="kubevirt.io/node-maintenance-operator git https://github.com/kubevirt/node-maintenance-operator">
     <meta name="go-import" content="kubevirt.io/containerdisks git https://github.com/kubevirt/containerdisks">
+    <meta name="go-import" content="kubevirt.io/virt-template git https://github.com/kubevirt/virt-template">
+    <meta name="go-import" content="kubevirt.io/virt-template-api git https://github.com/kubevirt/virt-template-api">
+    <meta name="go-import" content="kubevirt.io/virt-template-client-go git https://github.com/kubevirt/virt-template-client-go">
     <link rel="apple-touch-icon" sizes="72x72" href="{{ site.baseurl }}/assets/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/assets/favicon/favicon-16x16.png">


### PR DESCRIPTION
kubevirt.io/virt-template -> github.com/kubevirt/virt-template kubevirt.io/virt-template-api -> github.com/kubevirt/virt-template-api kubevirt.io/virt-template-client-go -> github.com/kubevirt/virt-template-client-go

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

Add go-import meta tags that enable vanity import paths for virt-template and its sub-repositories.

**Does this PR fix any issue?** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

> Fixes #

**Special notes for your reviewer**:
