### PR TITLE
docs: update minikube quickstart - kubevirt addon is fixed

### DIFF
--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -74,9 +74,6 @@ Below are two examples of how to install KubeVirt using the latest release.
 
 ### The easy way
 
-> warning "Addon currently broken"
-> An issue has been [reported](https://github.com/kubernetes/minikube/issues/15918) where more recent versions of minikube break the kubevirt addon. Fall back to the "in-depth" section below until this is resolved.
-
 * Installing KubeVirt can be as simple as the following command:
 
   ```bash


### PR DESCRIPTION
the kubevirt addon for minikube was broken due to missing curl in the 
bitnami/kubectl image. This has been fixed in minikube v1.38.0.

Reference: I raised a PR at kubernetes/minikube#22557 which was merged

This PR removes the "Addon currently broken" warning since the issue is resolved.
