### PR TITLE
docs(quickstart): flag macOS/Windows as unsupported for local quickstarts

### DIFF
--- a/pages/quickstart_kind.md
+++ b/pages/quickstart_kind.md
@@ -20,6 +20,10 @@ tags:
 
 Kind quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows allowing software developers to quickly get started working with Kubernetes.
 
+> warning "Not supported on macOS or Windows hosts"
+> KubeVirt needs Linux/KVM on the host kernel, which macOS and Windows don't provide (see [kubevirt/kubevirt#12410](https://github.com/kubevirt/kubevirt/issues/12410)).
+> If you're on a Mac, try the [devcontainer setup](https://github.com/kubevirt/kubevirt/pull/11830) or use the [cloud-provider quickstart](/quickstart_cloud/) instead.
+
 ## Prepare kind Kubernetes environment
 
 {% include quickstarts/kubectl.md %}

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -21,6 +21,9 @@ tags:
 
 [Minikube](https://minikube.sigs.k8s.io/docs/start/) quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows allowing software developers to quickly get started working with Kubernetes.
 
+> warning "Not supported on macOS or Windows hosts"
+> KubeVirt needs Linux/KVM on the host kernel, which macOS and Windows don't provide (see [kubevirt/kubevirt#12410](https://github.com/kubevirt/kubevirt/issues/12410)).
+> If you're on a Mac, try the [devcontainer setup](https://github.com/kubevirt/kubevirt/pull/11830) or use the [cloud-provider quickstart](/quickstart_cloud/) instead.
 
 ## Prepare minikube Kubernetes environment
 


### PR DESCRIPTION
Closes #960.

## Problem

\`pages/quickstart_minikube.md\` and \`pages/quickstart_kind.md\` currently tell readers that Minikube/kind \"sets up a local Kubernetes cluster on **macOS**, Linux, and Windows\". That's true for the *cluster*, but KubeVirt can't run on it: the hypervisor needs Linux/KVM on the *host* kernel, which macOS and Windows don't provide. [kubevirt/kubevirt#12410](https://github.com/kubevirt/kubevirt/issues/12410) and [kubevirt/user-guide#824](https://github.com/kubevirt/user-guide/issues/824) both track this. Mac users following the happy path get a failing VM and no pointer to the actual supported workflows.

## Fix

Add a \`> warning\` admonition at the top of both local quickstarts (minikube and kind) that:

- Explicitly calls out that macOS/Windows hosts aren't supported.
- Points at [kubevirt/kubevirt#12410](https://github.com/kubevirt/kubevirt/issues/12410) for the underlying reason.
- Offers two supported alternatives: the [devcontainer setup](https://github.com/kubevirt/kubevirt/pull/11830) and the existing [cloud-provider quickstart](https://kubevirt.io/quickstart_cloud/).

The cloud-provider page is untouched, it already runs on any host.

Using the existing \`> warning\` Liquid admonition style so the rendering matches the other in-page warnings (e.g. the \"Core DNS race condition\" and \"Nested virtualization\" blocks further down the same pages).