### PR TITLE
Move social media icons to navbar header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,6 +24,49 @@
       </li>
 
     </ul>
+
+    <ul class="navbar-nav navbar-social-icons ml-auto">
+      <li class="nav-item">
+        <a href="https://kubernetes.slack.com/archives/C8ED7RKFE" class="nav-link" title="Slack" aria-label="Join our Slack channel">
+          <i class="fab fa-slack"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{{ site.calendar }}" class="nav-link" title="Calendar" aria-label="See our events calendar">
+          <i class="fas fa-calendar"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{{ site.Mailinglist }}" class="nav-link" title="Mailing List" aria-label="Join our mailing list">
+          <i class="fas fa-envelope"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="https://github.com/{{ site.github_username }}" class="nav-link" title="GitHub" aria-label="Check our GitHub">
+          <i class="fab fa-github"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="https://twitter.com/{{ site.twitter_username }}" class="nav-link" title="Twitter" aria-label="Follow us on Twitter">
+          <i class="fab fa-twitter"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="https://www.youtube.com/channel/UC2FH36TbZizw25pVT1P3C3g/videos" class="nav-link" title="YouTube" aria-label="Subscribe to our YouTube channel">
+          <i class="fab fa-youtube"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="https://bsky.app/profile/kubevirt.bsky.social" class="nav-link" title="Bluesky" aria-label="Follow us on Bluesky">
+          <i class="fa-brands fa-bluesky"></i>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="https://fosstodon.org/@kubevirt" rel="me" class="nav-link" title="Mastodon" aria-label="Follow us on Mastodon">
+          <i class="fab fa-mastodon"></i>
+        </a>
+      </li>
+    </ul>
   </div>
 <script>
 function autocomplete(inp, arr) {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -178,3 +178,50 @@
 .navbar-brand {
   padding: 0;
 }
+
+// Social icons in the navbar header
+.navbar-social-icons {
+  flex-direction: row;
+  align-items: center;
+  margin-left: auto;
+  padding-left: 0.5rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.25);
+
+  .nav-item {
+    margin-bottom: 0;
+    border-bottom: none;
+
+    &:hover,
+    &:focus {
+      margin-bottom: 0;
+      border-bottom: none;
+    }
+  }
+
+  .nav-link {
+    padding: 0.25rem 0.4rem;
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.7);
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  @media (max-width: 991px) {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.25);
+    padding-left: 0;
+    padding-top: 0.5rem;
+    margin-top: 0.5rem;
+    margin-left: 0;
+
+    .nav-link {
+      font-size: 1.3rem;
+      padding: 0.4rem 0.6rem;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add social media icons (Slack, calendar, mailing list, GitHub, Twitter, YouTube, Bluesky, Mastodon) to the site header/navbar for immediate visibility without scrolling
- Icons use a dedicated `.navbar-social-icons` nav group positioned right-aligned in the navbar, separated by a subtle border
- Responsive: icons wrap and collapse into the hamburger menu on mobile (below 992px breakpoint)
- Footer social icons remain unchanged

Fixes #995

## Test plan
- [ ] Verify icons render correctly in the navbar on desktop
- [ ] Verify icons collapse into hamburger menu on mobile viewport
- [ ] Verify icon hover states (white on hover, semi-transparent at rest)
- [ ] Verify all icon links point to correct destinations
- [ ] Verify footer icons still display as before
- [ ] Test with Jekyll local build (`make run` or `bundle exec jekyll serve`)