### PR TITLE
fix: Add redirect for submodule pages

### DIFF
--- a/_plugins/go_import_redirects.rb
+++ b/_plugins/go_import_redirects.rb
@@ -1,0 +1,12 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  rules = site.pages
+    .select { |p| p.data["layout"] == "go-import" }
+    .map do |page|
+      package = (page.data["permalink"] || page.url).delete_prefix("/").chomp("/")
+      "/#{package}/*  /#{package}/  200"
+    end
+
+  next if rules.empty?
+
+  File.write(File.join(site.dest, "_redirects"), rules.join("\n") + "\n")
+end


### PR DESCRIPTION
**What this PR does / why we need it**:
Some projects like SSP operator have an `api` submodule at: `kubevirt.io/ssp-operator/api`
This PR adds redirects so that any submodule URL will redirect to the main project URL.
