### PR TITLE
fix: Use bundle exec rake in Netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "./_site"
-  command = "sed -i 's/jekyll build/jekyll build --future/g' Rakefile; rake; touch _site/.nojekyll"
+  command = "sed -i 's/jekyll build/jekyll build --future/g' Rakefile; bundle exec rake; touch _site/.nojekyll"


### PR DESCRIPTION
Noticed recent builds for the KubeVirt website were failing on Netlify. Had Claude investigate:

"Netlify's new build image (noble-new-builds, Ubuntu 24.04) installs bundled gems to /opt/build/cache/bundle without adding that directory to Ruby's load path. This causes bare rake to fail with LoadError when requiring html-proofer from the Rakefile.

Using bundle exec rake ensures rake runs in the bundle context where all gem dependencies are properly resolved."

**Special notes for your reviewer**:
