### PR TITLE
fix: Correct redirect for submodule pages

### DIFF
--- a/_plugins/go_import_redirects.rb
+++ b/_plugins/go_import_redirects.rb
@@ -3,7 +3,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
     .select { |p| p.data["layout"] == "go-import" }
     .map do |page|
       package = (page.data["permalink"] || page.url).delete_prefix("/").chomp("/")
-      "/#{package}/*  /#{package}/  200"
+      "/#{package}/*  /#{package}/index.html  200"
     end
 
   next if rules.empty?


### PR DESCRIPTION
**What this PR does / why we need it**:
My previous PR did not fix the redirect: https://github.com/kubevirt/kubevirt.github.io/pull/1025

The redirect needs to point to a specific HTML page, not a directory.
