### PR TITLE
go-import: Add a page for ssp-operator/api module

### DIFF
--- a/pages/ssp-operator-api.md
+++ b/pages/ssp-operator-api.md
@@ -1,0 +1,4 @@
+---
+layout: go-import
+permalink: /ssp-operator/api/
+---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds go-import page for API submodule of ssp-operator.

This is a fix to unblock SSP API module import, because the generic redirect does not work: https://github.com/kubevirt/kubevirt.github.io/pull/1030
