### PR TITLE
fix: update footer trademark disclaimer to LF Projects Series LLC

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,10 +44,9 @@
   </div>
   <div class="row">
     <div class="col text-sm-left footer-licensing" style="text-align: center;">
-      Copyright {{ 'now' | date: "%Y" }} The KubeVirt Contributors<br>
-      Copyright {{ 'now' | date: "%Y" }} The Linux Foundation. All Rights Reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.<br>
-      This site is powered by <a href="https://www.netlify.com/legal/open-source-policy/">Netlify</a>.
-      <p class="privacy-statement text-sm-left" style="text-align: center;">
+Copyright KubeVirt a Series of LF Projects, LLC<br>
+For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">https://lfprojects.org/policies/</a><br>
+This site is powered by <a href="https://www.netlify.com/legal/open-source-policy/">Netlify</a>.      <p class="privacy-statement text-sm-left" style="text-align: center;">
         <a href="/privacy" class="privacy-statement-link">Privacy Statement</a>
       </p>
   </div>


### PR DESCRIPTION
Fixes #1022

## What this PR does
Updates the website footer to include the new LF Projects 
Series LLC trademark disclaimer as required by CNCF guidelines.

## Changes
- Replaced old Linux Foundation trademark text
- Added "Copyright KubeVirt a Series of LF Projects, LLC"
- Added link to https://lfprojects.org/policies/
