### PR TITLE
docs: add Mac not supported note to quickstart pages

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,10 +44,9 @@
   </div>
   <div class="row">
     <div class="col text-sm-left footer-licensing" style="text-align: center;">
-      Copyright {{ 'now' | date: "%Y" }} The KubeVirt Contributors<br>
-      Copyright {{ 'now' | date: "%Y" }} The Linux Foundation. All Rights Reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.<br>
-      This site is powered by <a href="https://www.netlify.com/legal/open-source-policy/">Netlify</a>.
-      <p class="privacy-statement text-sm-left" style="text-align: center;">
+Copyright KubeVirt a Series of LF Projects, LLC<br>
+For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">https://lfprojects.org/policies/</a><br>
+This site is powered by <a href="https://www.netlify.com/legal/open-source-policy/">Netlify</a>.      <p class="privacy-statement text-sm-left" style="text-align: center;">
         <a href="/privacy" class="privacy-statement-link">Privacy Statement</a>
       </p>
   </div>

--- a/pages/quickstart_cloud.md
+++ b/pages/quickstart_cloud.md
@@ -20,6 +20,8 @@ tags: [
   ]
 ---
 
+> ⚠️ **Note:** These quickstarts are not supported on Mac. Please use a Linux environment instead. Alternatively, you can use [devContainers](https://github.com/kubevirt/kubevirt/pull/11830).
+
 ## Easy install using cloud providers
 
 KubeVirt can be used on cloud computing providers such as AWS, Azure, GCP, AliCloud.

--- a/pages/quickstart_kind.md
+++ b/pages/quickstart_kind.md
@@ -15,6 +15,8 @@ tags:
     "virtual machine",
   ]
 ---
+> ⚠️ **Note:** These quickstarts are not supported on Mac. Please use a Linux environment instead. Alternatively, you can use [devContainers](https://github.com/kubevirt/kubevirt/pull/11830).
+
 
 ## Easy install using kind
 

--- a/pages/quickstart_minikube.md
+++ b/pages/quickstart_minikube.md
@@ -17,7 +17,10 @@ tags:
   ]
 ---
 
-## Easy install using minikube
+
+
+
+> ⚠️ **Note:** These quickstarts are not supported on Mac. Please use a Linux environment instead. Alternatively, you can use [devContainers](https://github.com/kubevirt/kubevirt/pull/11830).## Easy install using minikube
 
 [Minikube](https://minikube.sigs.k8s.io/docs/start/) quickly sets up a local Kubernetes cluster on macOS, Linux, and Windows allowing software developers to quickly get started working with Kubernetes.
 


### PR DESCRIPTION
Fixes #960

## What this PR does
Adds a warning note to all quickstart pages clarifying 
that quickstarts are not supported on Mac.

## Changes
- Added Mac not supported note to quickstart_minikube.md
- Added Mac not supported note to quickstart_kind.md  
- Added Mac not supported note to quickstart_cloud.md

## References
- Issue: #960
- Related: https://github.com/kubevirt/kubevirt/issues/12410