### PR TITLE
Update Summit page for 2026

### DIFF
--- a/_data/site_nav_pages.yml
+++ b/_data/site_nav_pages.yml
@@ -1,4 +1,8 @@
 nav:
+  - title: Summit 2026
+    page: Summit
+    url: /summit/
+
   - title: Blogs
     page: Blogs
     url: /blogs/

--- a/pages/summit.md
+++ b/pages/summit.md
@@ -1,35 +1,41 @@
 ---
 layout: page
-title: KubeVirt Summit 2025!
+title: KubeVirt Summit 2026!
 permalink: /summit/
 order: 10
 ---
 
-The fifth online **KubeVirt Summit** took place on **October 16, 2025**!
+Join us for the sixth annual online **KubeVirt Summit** — celebrating **10 years of KubeVirt**!
 
 ## What is KubeVirt Summit?
 
 KubeVirt Summit is our annual online conference where the broader community gathers to showcase technical architecture, new features, proposed changes, and in-depth tutorials.
 
-We feature two tracks: one for developer-focused deep dives and one for end users sharing their deployment journeys and real-world use cases at scale.
+## When is it?
 
-## When was it?
+The 2026 edition will be held online on:
 
-The 2025 edition was held online on:
-
-- **Date:** October 16, 2025
+- **Date:** October 15, 2026
 - **Format:** One-day virtual event
-- **Time:** 12:00–17:00 UTC
-
+- **Time:** 12:00–16:00 UTC
 
 ## How do I register?
 
-Registration for the 2025 edition is now closed.  
-Check back later for updates and registration details for the 2026 Summit!
+**Register for free now at the [CNCF KubeVirt Summit event page](https://community2.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-kubevirt-summit-2026/)**
+
+## Key Dates
+
+- **Call for Proposals Deadline:** July 22, 2026
+  - Submit your talk at [sessionize.com/kubevirt-summit-2026](https://sessionize.com/kubevirt-summit-2026/)
+- **CfP Notifications:** August 3, 2026
+- **Schedule Announcement:** August 5, 2026
+- **Event Date:** October 15, 2026
 
 ## Schedule
 
-_The detailed schedule for the 2026 Summit will be published soon._
+The detailed schedule for the 2026 Summit will be published on the CNCF event page after August 5, 2026.
+
+## Previous Sessions from KubeVirt Summit
 Past sessions from [earlier editions remain available](/videos/kubevirt-summit) as reference.
 
 ## Have questions?


### PR DESCRIPTION
Update the summit page with KubeVirt Summit 2026 details:
- Add 2026 event date and registration link based on CNCF event page
- Update navigation to include Summit 2026 tab

In previous years we've included a lot more information for the event here, including duplicating schedule information etc.  Downside is many additional PRs leading up to the event. This time I've opted for a slim approach that does not need to be updated until after the event and leaves the schedule etc to the CNCF event page. 


